### PR TITLE
fix(security): restrict dcmqrscp Peers configuration access

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Any DICOM-capable application can connect to the PACS via the host-mapped ports:
 | Host | `<docker-host-ip>` or `localhost` |
 | Port | `11112` (primary), `11113` (secondary) |
 | Called AE Title | `DCMTK_PACS` or `DCMTK_PAC2` |
-| Calling AE Title | Any (Peers = ANY) |
+| Calling AE Title | Any (Peers = ANY in test config — see [Security Notes](#security-notes)) |
 
 For C-MOVE **from** the PACS **to** an external application, the application must be
 registered in the dcmqrscp HostTable. Edit `config/dcmqrscp-primary.cfg.template`
@@ -296,6 +296,66 @@ Key sections:
 - **HostTable**: Defines known peers for C-MOVE destination routing
 - **AETable**: Defines storage areas, access mode, and capacity limits
 - **Global**: Network port, PDU size, max associations
+
+## Security Notes
+
+**The default configuration shipped in this repository is intended for
+isolated test environments only and is NOT safe for production use.**
+
+### Default behavior: `ANY` Peers
+
+Both `config/dcmqrscp-primary.cfg.template` and
+`config/dcmqrscp-secondary.cfg.template` set the AETable Peers field to
+`ANY`:
+
+```
+AETable BEGIN
+  ${AE_TITLE}  ${STORAGE_DIR}/${AE_TITLE}  RW  (...)  ANY
+AETable END
+```
+
+`ANY` instructs `dcmqrscp` to accept associations from **any** DICOM SCU
+on the network without verifying the Calling AE Title. This is convenient
+for local integration testing but exposes the PACS to:
+
+- Unauthenticated C-STORE from arbitrary peers (data poisoning, malware
+  delivery via DICOM payloads).
+- Unauthenticated C-FIND / C-MOVE that may exfiltrate PHI (Protected
+  Health Information).
+- Compliance violations under HIPAA, GDPR, and the Korean Personal
+  Information Protection Act, all of which require restricting access to
+  known callers.
+
+### Production-safe alternative
+
+For any deployment that touches a non-isolated network, replace `ANY`
+with a `HostTable` + `all_peers` whitelist that names exactly which AE
+Titles are allowed to connect. A complete, annotated example is provided
+at:
+
+```
+config/dcmqrscp-production.cfg.example
+```
+
+That file:
+
+1. Lists each modality / viewer / archive explicitly in `HostTable`.
+2. Aggregates them under a symbolic name (`all_peers`).
+3. References that name in the `AETable` Peers field instead of `ANY`.
+
+### Additional hardening
+
+Even with a peer whitelist, a production deployment should add:
+
+- **Network isolation**: Run `dcmqrscp` behind a firewall or on a private
+  VLAN. DICOM is not encrypted by default.
+- **TLS**: Use `dcmqrscp --enable-tls` (or a TLS-terminating proxy) to
+  protect data in transit.
+- **Audit logging**: Set `LOG_LEVEL=info` (or `debug` during incident
+  triage) and forward `dcmqrscp` logs to a central log store. Alert on
+  rejected associations.
+- **Access reviews**: Periodically audit the HostTable; remove
+  decommissioned peers and rotate AE Titles when needed.
 
 ## Project Structure
 

--- a/config/dcmqrscp-primary.cfg.template
+++ b/config/dcmqrscp-primary.cfg.template
@@ -1,4 +1,21 @@
 #
+# ============================================================================
+# WARNING: TEST ENVIRONMENT ONLY - DO NOT USE IN PRODUCTION
+# ============================================================================
+# This template uses "ANY" as the Peers entry in the AETable below, which
+# allows any DICOM SCU on the network to connect, store, query, and retrieve
+# without Calling AE Title verification.
+#
+# This is acceptable for an isolated, ephemeral test environment but is
+# UNSAFE for any production-adjacent deployment. Unauthenticated DICOM
+# access can violate HIPAA, GDPR, the Korean Personal Information
+# Protection Act, and similar healthcare/privacy regulations.
+#
+# For a production-safe configuration that restricts Peers to a known
+# whitelist via HostTable + all_peers, see:
+#   config/dcmqrscp-production.cfg.example
+# ============================================================================
+#
 # dcmqrscp configuration - Primary PACS Server
 # Processed by envsubst at container startup
 #

--- a/config/dcmqrscp-production.cfg.example
+++ b/config/dcmqrscp-production.cfg.example
@@ -1,0 +1,66 @@
+#
+# ============================================================================
+# dcmqrscp configuration - Production-Safe Example
+# ============================================================================
+# This example demonstrates how to restrict DICOM access to a known set of
+# peers using HostTable + a named whitelist (here: "all_peers").
+#
+# Key difference from the test templates:
+#   - The AETable Peers entry uses the HostTable whitelist symbolic name
+#     ("all_peers") instead of the wildcard "ANY".
+#   - dcmqrscp will REJECT any association whose Calling AE Title does not
+#     match an entry mapped under the configured peer group.
+#
+# Usage:
+#   1. Copy this file to a non-template name (e.g., dcmqrscp-production.cfg).
+#   2. Replace the symbolic peer entries with the AE Titles, hostnames, and
+#      ports of YOUR real DICOM modalities and viewers.
+#   3. Replace the placeholder values (AE_TITLE, STORAGE_DIR, etc.) with
+#      concrete production values - this file is NOT processed by envsubst
+#      unless you wire it into your own entrypoint.
+#   4. Mount the resulting file into the container at the path expected by
+#      your entrypoint (default: /etc/dcmtk/dcmqrscp-primary.cfg.template).
+#
+# Security checklist before going live:
+#   - Run dcmqrscp behind a network boundary (firewall / private VLAN).
+#   - Use TLS (dcmqrscp --enable-tls ...) where supported.
+#   - Audit the HostTable so only known modalities are listed.
+#   - Rotate AE Titles if a peer is decommissioned.
+#   - Monitor dcmqrscp logs for rejected associations and alert on spikes.
+# ============================================================================
+
+# Global Configuration
+NetworkTCPPort  = 11112
+MaxPDUSize      = 16384
+MaxAssociations = 16
+
+# HostTable: defines KNOWN, AUTHORIZED DICOM peers.
+# Format: symbolic_name = (AETitle, hostname, port)
+#
+# Replace each entry below with a real modality / viewer / archive.
+# The "all_peers" line aggregates them into a single whitelist that the
+# AETable references by name.
+HostTable BEGIN
+  modality_ct1   = (CT_SCANNER_01,  ct1.hospital.example,         11112)
+  modality_mr1   = (MR_SCANNER_01,  mr1.hospital.example,         11112)
+  viewer_main    = (PACS_VIEWER,    viewer.hospital.example,      11112)
+  archive_dr     = (DR_ARCHIVE,     archive.dr.hospital.example,  11112)
+
+  all_peers      = modality_ct1, modality_mr1, viewer_main, archive_dr
+HostTable END
+
+# VendorTable: optional grouping by vendor or department.
+VendorTable BEGIN
+  "Approved Peers" = all_peers
+VendorTable END
+
+# AETable: defines storage areas for this SCP.
+# Format: AETitle StorageDirectory AccessMode (MaxStudies, MaxBytesPerStudy) Peers
+#
+# IMPORTANT: The final field is "all_peers" (the HostTable whitelist),
+# NOT "ANY". This is the substitution that converts the test template
+# into a production-safe configuration. Any SCU whose Calling AE Title
+# does not resolve through "all_peers" will be rejected.
+AETable BEGIN
+  PROD_PACS  /var/dicom/db/PROD_PACS  RW  (10000, 4096mb)  all_peers
+AETable END

--- a/config/dcmqrscp-secondary.cfg.template
+++ b/config/dcmqrscp-secondary.cfg.template
@@ -1,4 +1,21 @@
 #
+# ============================================================================
+# WARNING: TEST ENVIRONMENT ONLY - DO NOT USE IN PRODUCTION
+# ============================================================================
+# This template uses "ANY" as the Peers entry in the AETable below, which
+# allows any DICOM SCU on the network to connect, store, query, and retrieve
+# without Calling AE Title verification.
+#
+# This is acceptable for an isolated, ephemeral test environment but is
+# UNSAFE for any production-adjacent deployment. Unauthenticated DICOM
+# access can violate HIPAA, GDPR, the Korean Personal Information
+# Protection Act, and similar healthcare/privacy regulations.
+#
+# For a production-safe configuration that restricts Peers to a known
+# whitelist via HostTable + all_peers, see:
+#   config/dcmqrscp-production.cfg.example
+# ============================================================================
+#
 # dcmqrscp configuration - Secondary PACS Server
 # Processed by envsubst at container startup
 #

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -29,6 +29,7 @@ DCMTK_LOG_LEVEL=$(map_log_level)
 
 # ── Logging helpers ──────────────────────────────────
 log_info()  { echo "[entrypoint] INFO:  $*"; }
+log_warn()  { echo "[entrypoint] WARN:  $*" >&2; }
 log_error() { echo "[entrypoint] ERROR: $*" >&2; }
 
 # ── Generate test data ───────────────────────────────
@@ -57,6 +58,13 @@ start_pacs_server() {
     else
         log_error "Config template not found: ${CONFIG_TEMPLATE}"
         exit 1
+    fi
+
+    # Security check: warn if rendered config uses 'ANY' Peers
+    # (test default; not safe for production - see config/dcmqrscp-production.cfg.example)
+    if grep -Eq '^[[:space:]]*[^#].*[[:space:]]ANY[[:space:]]*$' /tmp/dcmqrscp.cfg; then
+        log_warn "dcmqrscp AETable uses 'ANY' Peers - any SCU may connect without AE Title verification."
+        log_warn "This is TEST-ONLY. For production, see config/dcmqrscp-production.cfg.example."
     fi
 
     # Generate test data if enabled


### PR DESCRIPTION
## What

### Summary
Hardens the dcmqrscp configuration story so that operators do not silently
deploy a PACS that accepts unauthenticated DICOM associations. The default
templates now carry a prominent TEST-ONLY warning, a production-safe
example demonstrates the recommended HostTable + whitelist pattern, the
README has a Security Notes section, and the entrypoint emits a startup
warning when the rendered config still uses `ANY` Peers.

### Change Type
- [ ] Feature
- [x] Bugfix (security hardening)
- [ ] Refactor
- [x] Documentation
- [ ] Test
- [ ] Chore

### Affected Components
- `config/dcmqrscp-primary.cfg.template` - TEST-ONLY header
- `config/dcmqrscp-secondary.cfg.template` - TEST-ONLY header
- `config/dcmqrscp-production.cfg.example` - new production-safe example
- `README.md` - new Security Notes section + cross-reference
- `scripts/entrypoint.sh` - startup WARN when ANY Peers is in effect

## Why

### Problem
Both dcmqrscp templates use `ANY` as the AETable Peers entry. `ANY`
disables Calling AE Title verification, so any DICOM SCU on the network
can connect, store, query, and retrieve. This is fine for the isolated
test environment the project targets, but a reader copying these
templates into a staging or production deployment can unknowingly expose
PHI and violate HIPAA / GDPR / Korean Personal Information Protection Act.

### Related Issues
- Closes #1

### Alternatives Considered
1. Replace `ANY` outright in the test templates - rejected; it would
   break the existing local test workflow that intentionally accepts
   arbitrary AE Titles.
2. Documentation-only change - rejected; an operator who never opens
   the README can still ship the unsafe default. The runtime warning
   guarantees the issue is surfaced on every container start.

## Where

### Files Changed
| Path | Change |
|------|--------|
| `config/dcmqrscp-primary.cfg.template` | Add TEST-ONLY header comment block |
| `config/dcmqrscp-secondary.cfg.template` | Add TEST-ONLY header comment block |
| `config/dcmqrscp-production.cfg.example` | New file - production-safe example with HostTable + all_peers whitelist |
| `README.md` | New `## Security Notes` section + cross-reference from external-app table |
| `scripts/entrypoint.sh` | Add `log_warn` helper and post-envsubst grep that warns when `ANY` is in the rendered config |

### Architecture / API / Database Impact
None. No DICOM behavior changes for the existing test workflow; the
runtime addition is a single conditional log line that fires only when
the rendered config still contains an `ANY` Peers entry.

## How

### Implementation Details
1. **Template headers**: prepended a 16-line comment block to both
   `.cfg.template` files explaining the risk and pointing to the
   production example. Matches existing `#` comment style.
2. **Production example**: `dcmqrscp-production.cfg.example` mirrors
   the primary template structure but replaces the wildcard `ANY` with
   `all_peers`, and replaces envsubst placeholders with concrete
   sample values plus inline guidance and a pre-deployment security
   checklist.
3. **README Security Notes**: placed between the existing `Configuration`
   section and `Project Structure` so it sits alongside the dcmqrscp
   docs that introduce the templates. The external-app table now
   cross-references this section.
4. **Entrypoint warning**: added `log_warn` helper and a single `grep -E`
   over `/tmp/dcmqrscp.cfg` after `envsubst` runs. The regex matches
   non-comment lines ending in ` ANY`, so production configs (which
   end with the whitelist symbol) stay silent.

### Testing Done
- `bash -n scripts/entrypoint.sh` - syntax check passes.
- Manually traced the regex against both rendered templates (matches
  the AETable line) and against the production example (does not match).
- File rendering paths and template structure are unchanged for the
  existing test workflow.

### Breaking Changes
None. All edits are additive: comments, a new file, a new docs section,
and a single conditional log line.

### Rollback
Revert this PR. No data, schema, or runtime behavior changes beyond an
extra log line on startup.