### PR TITLE
fix(entrypoint): gate dcmqridx re-indexing with marker file

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,13 @@ rm -rf data/ct data/mr data/cr
 docker compose restart test-client
 ```
 
+> **Note:** The `pacs-server` indexes test DICOM files into its database on
+> first startup and writes a marker file at `<storage>/<AE_TITLE>/.indexed`
+> to skip re-indexing on subsequent restarts. After adding new DICOM files
+> to the storage area, delete the marker (or wipe the storage volume) to
+> force a re-index. See [docs/06_dcmqridx_behavior.md](docs/06_dcmqridx_behavior.md)
+> for details on the underlying `dcmqridx` semantics.
+
 ## Configuration
 
 ### Environment Variables

--- a/docs/06_dcmqridx_behavior.md
+++ b/docs/06_dcmqridx_behavior.md
@@ -1,0 +1,94 @@
+# dcmqridx Idempotency Behavior
+
+> Investigation of `dcmqridx` index registration semantics on repeated invocations
+> with the same SOP Instance UIDs (relevant to container restart scenarios).
+>
+> Related issue: `kcenon/dcmtk-docker#5`
+
+## Summary
+
+When `dcmqridx` is run multiple times on the same DICOM dataset (same SOP
+Instance UIDs), the resulting `index.dat` file does **not** grow unboundedly,
+and duplicate logical entries are **not** created. DCMTK detects existing SOP
+Instance UIDs and reuses the corresponding record slots in `index.dat`.
+
+This means re-running `dcmqridx` across container restarts is functionally safe
+with respect to index integrity. However, it still performs unnecessary I/O
+work proportional to the test dataset size on every container start.
+
+## Source-level Evidence
+
+The relevant code path in DCMTK (verified against the upstream `master` branch
+of `DCMTK/dcmtk`):
+
+1. `dcmqridx.cc` invokes `DcmQueryRetrieveIndexDatabaseHandle::storeRequest()`
+   for each input DICOM file.
+
+   Source: `dcmqrdb/apps/dcmqridx.cc` — call site:
+   `hdl.storeRequest(sclass, sinst, opt_imageFile, &status, opt_isNewFlag);`
+
+2. `storeRequest()` (in `dcmqrdb/libsrc/dcmqrdbi.cc`) calls
+   `removeDuplicateImage(SOPInstanceUID, StudyInstanceUID, pStudyDesc, newImageFileName)`
+   before adding the new record. This function searches existing index records
+   for a matching SOP Instance UID and, if found:
+   - removes the previous idx record (via `DB_IdxRemove`),
+   - conditionally deletes the previous image file only if its path differs
+     from the file being re-registered, and
+   - updates study metadata (image count, study size).
+
+3. `DB_IdxRemove(idx)` does **not** truncate `index.dat`. It overwrites the
+   record at its current offset with a blank record (`filename[0] = '\0'`).
+   The DCMTK comment in source explicitly states:
+
+   > "Just put a record with filename == ''"
+
+   Subsequent calls to `DB_IdxAdd` reuse these tombstoned slots:
+
+   > "A place is free if filename is empty"
+
+### Implications
+
+| Aspect | Behavior on re-indexing same SOP Instance UIDs |
+|--------|------------------------------------------------|
+| Logical duplicates in index | None — the previous record is removed first. |
+| `index.dat` file size | Does not grow per re-run; tombstone slots are reused. |
+| Image files on disk | Preserved when re-registered with the same path. |
+| CPU / I/O cost | Linear in dataset size; runs every time on each invocation. |
+| Behavior across DCMTK versions | Verified against current upstream; may change in the future. |
+
+## Reference Sources
+
+- DCMTK upstream repository (verified against `master` at investigation time):
+  `https://github.com/DCMTK/dcmtk`
+- `dcmqrdb/apps/dcmqridx.cc` — entry point for the `dcmqridx` tool
+- `dcmqrdb/libsrc/dcmqrdbi.cc` — `storeRequest`, `removeDuplicateImage`,
+  `DB_IdxRemove`, `DB_IdxAdd`
+- DCMTK Q/R database documentation:
+  `https://support.dcmtk.org/docs/classDcmQueryRetrieveIndexDatabaseHandle.html`
+
+## Operational Decision
+
+Despite `dcmqridx` being effectively idempotent with respect to `index.dat`
+growth and logical entry uniqueness, the entrypoint script applies a
+conservative marker-file guard at `${STORAGE_DIR}/${AE_TITLE}/.indexed`:
+
+- After the first successful indexing run, the marker file is created.
+- On subsequent container starts, if the marker exists, the indexing block
+  is skipped entirely.
+- To force re-indexing (for example, after adding new test DICOM files or
+  changing AE title), delete the marker file or remove the storage volume.
+
+### Rationale for the marker
+
+1. **Avoids redundant I/O** on every container restart, which becomes
+   noticeable as the synthetic dataset grows.
+2. **Defense in depth** — if the upstream DCMTK behavior changes in a future
+   release such that re-indexing produces growth or duplicates, this guard
+   prevents regression without requiring code changes here.
+3. **Explicit, observable state** — the presence or absence of the marker
+   makes the indexing decision visible during troubleshooting.
+
+The trade-off is that newly added test DICOM files are not picked up
+automatically across restarts; the user must either delete the marker file
+or wipe the storage volume. This is documented in `README.md` and in the
+inline comment block in `scripts/entrypoint.sh`.

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -70,14 +70,33 @@ start_pacs_server() {
     # Generate test data if enabled
     maybe_generate_test_data
 
-    # If test data was generated, register it with the PACS database
+    # If test data was generated, register it with the PACS database.
+    #
+    # Indexing is gated by a marker file at "${STORAGE_DIR}/${AE_TITLE}/.indexed"
+    # to avoid redundant work on every container restart. Source review of
+    # DCMTK shows that re-indexing the same SOP Instance UIDs does not grow
+    # index.dat unboundedly (duplicate records are detected and tombstone
+    # slots are reused). The marker is therefore a defensive optimization,
+    # not a correctness fix. To force re-indexing (e.g. after adding new
+    # test DICOM files), delete the marker file or wipe the storage volume.
+    # See docs/06_dcmqridx_behavior.md for the source-level analysis.
     if [ "${GENERATE_TEST_DATA}" = "true" ] && [ -d "${TEST_DATA_DIR}" ]; then
-        local dcm_count
-        dcm_count=$(find "${TEST_DATA_DIR}" -name "*.dcm" 2>/dev/null | wc -l)
-        if [ "$dcm_count" -gt 0 ]; then
-            log_info "Registering ${dcm_count} test DICOM files with PACS database..."
-            find "${TEST_DATA_DIR}" -name "*.dcm" -exec \
-                dcmqridx "${STORAGE_DIR}/${AE_TITLE}" {} + 2>/dev/null || true
+        local marker="${STORAGE_DIR}/${AE_TITLE}/.indexed"
+        if [ -f "$marker" ]; then
+            log_info "Skipping dcmqridx; marker present at ${marker} (delete to force re-index)"
+        else
+            local dcm_count
+            dcm_count=$(find "${TEST_DATA_DIR}" -name "*.dcm" 2>/dev/null | wc -l)
+            if [ "$dcm_count" -gt 0 ]; then
+                log_info "Registering ${dcm_count} test DICOM files with PACS database..."
+                if find "${TEST_DATA_DIR}" -name "*.dcm" -exec \
+                        dcmqridx "${STORAGE_DIR}/${AE_TITLE}" {} + 2>/dev/null; then
+                    touch "$marker"
+                    log_info "Indexing complete; marker created at ${marker}"
+                else
+                    log_warn "dcmqridx returned non-zero; marker not created (will retry next start)"
+                fi
+            fi
         fi
     fi
 


### PR DESCRIPTION
Closes #5

## What

Investigate `dcmqridx` idempotency behavior on container restart and apply a
conservative marker-file gate to skip redundant re-indexing.

### Change Type
- [x] Bugfix (defensive correctness)
- [x] Documentation (DCMTK behavior reference)

### Affected Components
- `scripts/entrypoint.sh` — gate dcmqridx invocation with `.indexed` marker
- `docs/06_dcmqridx_behavior.md` — new investigation document with source citations
- `README.md` — note marker behavior alongside regenerate-test-data instructions

## Why

`scripts/entrypoint.sh:67-73` ran `dcmqridx` unconditionally on every container
start when `GENERATE_TEST_DATA=true` and DCM files were present. Idempotency
of `dcmqridx` was unverified, raising the concern that repeated registration
of the same SOP Instance UIDs across restarts could grow `index.dat`
unboundedly or create logical duplicates.

### Investigation finding
Source review of upstream DCMTK (`DCMTK/dcmtk` `master`, files
`dcmqrdb/apps/dcmqridx.cc` and `dcmqrdb/libsrc/dcmqrdbi.cc`) shows that
`storeRequest()` invokes `removeDuplicateImage()` before adding records, and
`DB_IdxRemove` writes a tombstone (`filename[0] = '\0'`) at the existing
record offset. `DB_IdxAdd` later reuses these slots ("A place is free if
filename is empty"). Therefore:

- `index.dat` does NOT grow per re-run for the same SOP Instance UIDs.
- No logical duplicates are produced.

The investigation is documented in `docs/06_dcmqridx_behavior.md` with the
specific source paths and quoted comments.

### Why apply the marker anyway
Even though `dcmqridx` is effectively idempotent for index integrity, the
marker-file gate is still applied for two reasons:

1. **Avoids redundant I/O** on every container restart, proportional to test
   dataset size.
2. **Defense in depth** — if the upstream behavior ever changes in a future
   DCMTK release, this guard prevents regression without code changes here.

## Who

- Reviewers: maintainers of `kcenon/dcmtk-docker`

## When

Normal priority. No release pinning.

## Where

| File | Change |
|------|--------|
| `scripts/entrypoint.sh` | Marker-file gate around the dcmqridx block in `start_pacs_server`; marker only written on successful exit. |
| `docs/06_dcmqridx_behavior.md` | New: source-level analysis of dcmqridx + index.dat semantics, with citations and operational rationale. |
| `README.md` | One paragraph next to "regenerate test data" describing the `<storage>/<AE_TITLE>/.indexed` marker and how to force re-index. |

## How

### Implementation

- `MARKER="${STORAGE_DIR}/${AE_TITLE}/.indexed"`
- If marker exists at the start of the indexing block, log and skip.
- Otherwise run `dcmqridx`; if it exits successfully, `touch "$marker"`.
- On non-zero exit, the marker is NOT created — the next start will retry.

The simpler form ("skip if marker exists at all") is used. Re-indexing after
adding new DICOMs requires deleting the marker or wiping the storage volume,
which is documented in both the README and the inline comment block that
points to `docs/06_dcmqridx_behavior.md`.

### Testing Done

- `bash -n scripts/entrypoint.sh` — syntax check passes.
- Logical walkthrough of the marker control flow (first start vs. restart,
  success vs. failure, AE-title-namespaced storage).
- No test files reference `dcmqridx` or the marker, so existing tests
  (`tests/test-*.sh`) are unaffected.

### Test Plan

Live restart-cycle verification was NOT performed in this change because the
sandbox environment does not provide a Docker daemon (`docker info` fails).
The behavior is design-verified through the DCMTK source review cited in
`docs/06_dcmqridx_behavior.md`, and the gating logic is conservative — no
harm if `dcmqridx` is, as the source indicates, already effectively
idempotent.

For maintainers running this locally:
1. `./pacs.sh up` with `GENERATE_TEST_DATA=true`.
2. Confirm log line `Indexing complete; marker created at ...`.
3. `docker compose restart pacs-server` and verify log line
   `Skipping dcmqridx; marker present at ...`.
4. Compare `index.dat` size and entry count between restarts (should be
   constant).
5. To exercise the force-re-index path: `rm <storage>/<AE_TITLE>/.indexed`
   and restart; the registration step should run again.

### Breaking Changes

None. The marker file lives inside the storage volume; existing volumes
without the marker simply re-index once and create the marker.

### Rollback

Revert the PR. No data migration needed; the marker file is harmless and can
be left in place (or deleted, if the user wants to retry indexing under the
old code path).

## Acceptance Criteria

- [x] Idempotency behavior of `dcmqridx` is documented in `docs/`.
- [x] Marker-file gating applied to indexing block (regardless of investigation outcome).
- [x] Inline comment in entrypoint explains the rationale and links to the doc.
- [ ] No measurable index growth across N container restarts with the same synthetic dataset — design-verified via source review only; live measurement requires a Docker daemon and is outside the sandbox capability.
