### PR TITLE
feat(test-data): add synthetic PixelData support

### DIFF
--- a/.github/workflows/test-isolation.yml
+++ b/.github/workflows/test-isolation.yml
@@ -86,6 +86,57 @@ jobs:
         if: always()
         run: docker compose down -v
 
+  test-pixeldata:
+    name: test-pixeldata.sh with GENERATE_PIXEL_DATA=true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Stage .env from defaults with PixelData enabled
+        run: |
+          cp env.default .env
+          # Flip the opt-in switch and verify it took
+          sed -i 's/^GENERATE_PIXEL_DATA=.*/GENERATE_PIXEL_DATA=true/' .env
+          grep '^GENERATE_PIXEL_DATA=true' .env
+
+      - name: Build and start stack
+        run: |
+          docker compose up -d --build
+          sleep 5
+
+      - name: Wait for primary PACS to be healthy
+        run: |
+          for i in $(seq 1 60); do
+            status=$(docker inspect -f '{{.State.Health.Status}}' pacs-server 2>/dev/null || echo "starting")
+            if [ "$status" = "healthy" ]; then
+              echo "pacs-server is healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ERROR: pacs-server did not become healthy in time"
+          docker compose logs pacs-server
+          exit 1
+
+      - name: Run test-pixeldata.sh
+        run: docker compose exec -T -e GENERATE_PIXEL_DATA=true test-client /tests/test-pixeldata.sh
+
+      - name: Verify findscu/movescu still recognize the files
+        run: |
+          docker compose exec -T test-client /tests/test-find.sh
+          docker compose exec -T test-client /tests/test-move.sh
+
+      - name: Dump logs on failure
+        if: failure()
+        run: |
+          docker compose logs pacs-server || true
+          docker compose logs test-client || true
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose down -v
+
   test-store-idempotency:
     name: test-store.sh twice (idempotency)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -255,6 +255,34 @@ rm -rf data/ct data/mr data/cr
 docker compose restart test-client
 ```
 
+#### Synthetic PixelData (optional)
+
+By default, generated files carry only metadata (Patient/Study/Series/Image/SOP modules)
+— enough to exercise the DICOM **network layer** (C-STORE, C-FIND, C-MOVE) but not
+the **image pipeline** (decode, window/level, render). To make the synthetic files
+usable by viewers and rendering pipelines, set `GENERATE_PIXEL_DATA=true`:
+
+```bash
+# Wipe existing test data and re-generate with PixelData embedded
+rm -rf data/ct data/mr data/cr
+GENERATE_PIXEL_DATA=true docker compose up -d --force-recreate pacs-server
+```
+
+When enabled, every CT/MR/CR instance gains an Image Pixel Module
+(`Rows`, `Columns`, `BitsAllocated`, `BitsStored`, `HighBit`, `PixelRepresentation`,
+`SamplesPerPixel`, `PhotometricInterpretation`) and a `(7FE0,0010) OW` element
+containing a deterministic 64×64 16-bit horizontal gradient. Override the
+dimensions with `PIXEL_DATA_ROWS` / `PIXEL_DATA_COLS`.
+
+Verify with `dcmdump`:
+
+```bash
+docker compose exec test-client dcmdump /dicom/testdata/ct/ct_pat001_1.dcm | grep -E 'PixelData|Rows|Columns'
+```
+
+A smoke test that runs `dcm2pnm` against a generated file is included as
+`tests/test-pixeldata.sh` (auto-skipped when `GENERATE_PIXEL_DATA` is unset).
+
 > **Note:** The `pacs-server` indexes test DICOM files into its database on
 > first startup and writes a marker file at `<storage>/<AE_TITLE>/.indexed`
 > to skip re-indexing on subsequent restarts. After adding new DICOM files
@@ -289,6 +317,9 @@ cp env.default .env
 | `MAX_BYTES_PER_STUDY` | `1024mb` | Maximum bytes per study |
 | `LOG_LEVEL` | `info` | Log level: debug, info, warn, error |
 | `GENERATE_TEST_DATA` | `true` | Generate synthetic data on startup |
+| `GENERATE_PIXEL_DATA` | `false` | Embed deterministic 16-bit MONOCHROME2 PixelData in generated files |
+| `PIXEL_DATA_ROWS` | `64` | Synthetic image rows when `GENERATE_PIXEL_DATA=true` |
+| `PIXEL_DATA_COLS` | `64` | Synthetic image columns when `GENERATE_PIXEL_DATA=true` |
 | `OID_ROOT` | `1.2.826.0.1.3680043.8.499` | OID root for test UIDs |
 
 ### dcmqrscp Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       - MAX_BYTES_PER_STUDY=${MAX_BYTES_PER_STUDY:-1024mb}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - GENERATE_TEST_DATA=${GENERATE_TEST_DATA:-true}
+      - GENERATE_PIXEL_DATA=${GENERATE_PIXEL_DATA:-false}
+      - PIXEL_DATA_ROWS=${PIXEL_DATA_ROWS:-64}
+      - PIXEL_DATA_COLS=${PIXEL_DATA_COLS:-64}
       - TEST_DATA_DIR=/dicom/testdata
       - OID_ROOT=${OID_ROOT:-1.2.826.0.1.3680043.8.499}
       # Peer configuration for HostTable
@@ -114,6 +117,9 @@ services:
       - STORESCP_HOST=storescp-receiver
       - STORESCP_AE_TITLE=${STORESCP_AE_TITLE:-STORE_SCP}
       - GENERATE_TEST_DATA=${GENERATE_TEST_DATA:-true}
+      - GENERATE_PIXEL_DATA=${GENERATE_PIXEL_DATA:-false}
+      - PIXEL_DATA_ROWS=${PIXEL_DATA_ROWS:-64}
+      - PIXEL_DATA_COLS=${PIXEL_DATA_COLS:-64}
       - TEST_DATA_DIR=/dicom/testdata
       - OID_ROOT=${OID_ROOT:-1.2.826.0.1.3680043.8.499}
     volumes:

--- a/env.default
+++ b/env.default
@@ -30,3 +30,12 @@ LOG_LEVEL=info
 # -- Test Data --
 GENERATE_TEST_DATA=true
 OID_ROOT=1.2.826.0.1.3680043.8.499
+
+# Optional: synthesize MONOCHROME2 PixelData (default off to preserve current
+# behavior). When enabled, every generated CT/MR/CR instance carries a
+# deterministic 64x64 16-bit gradient in (7FE0,0010) so downstream viewer /
+# rendering tests have actual pixels to decode. Override the dimensions via
+# PIXEL_DATA_ROWS / PIXEL_DATA_COLS.
+GENERATE_PIXEL_DATA=false
+# PIXEL_DATA_ROWS=64
+# PIXEL_DATA_COLS=64

--- a/scripts/generate-test-data.sh
+++ b/scripts/generate-test-data.sh
@@ -9,6 +9,9 @@ set -e
 
 OUTPUT_DIR="${1:-${TEST_DATA_DIR:-/dicom/testdata}}"
 OID_ROOT="${OID_ROOT:-1.2.826.0.1.3680043.8.499}"
+GENERATE_PIXEL_DATA="${GENERATE_PIXEL_DATA:-false}"
+PIXEL_DATA_ROWS="${PIXEL_DATA_ROWS:-64}"
+PIXEL_DATA_COLS="${PIXEL_DATA_COLS:-64}"
 
 # Skip if test data already exists
 if [ -d "${OUTPUT_DIR}" ] && [ "$(find "${OUTPUT_DIR}" -name '*.dcm' 2>/dev/null | wc -l)" -gt 0 ]; then
@@ -21,9 +24,47 @@ mkdir -p "${OUTPUT_DIR}/ct" "${OUTPUT_DIR}/mr" "${OUTPUT_DIR}/cr"
 echo "[generate-test-data] Generating synthetic DICOM files..."
 echo "[generate-test-data] OID root: ${OID_ROOT}"
 echo "[generate-test-data] Output: ${OUTPUT_DIR}"
+if [ "${GENERATE_PIXEL_DATA}" = "true" ]; then
+    echo "[generate-test-data] PixelData: ${PIXEL_DATA_ROWS}x${PIXEL_DATA_COLS} 16-bit MONOCHROME2 (deterministic gradient)"
+else
+    echo "[generate-test-data] PixelData: disabled (set GENERATE_PIXEL_DATA=true to enable)"
+fi
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "${TMPDIR}"' EXIT
+
+# ── Helper: write a deterministic 16-bit MONOCHROME2 pixel buffer ─────
+# A horizontal gradient (constant per column, smooth 0..65535 across cols)
+# is generated once per (rows, cols) and cached in TMPDIR for reuse.
+# Output: little-endian uint16 raw bytes, total = rows * cols * 2.
+# Args: rows cols outfile
+generate_pixel_data_file() {
+    local rows="$1"
+    local cols="$2"
+    local outfile="$3"
+
+    local row_seq=""
+    local x val lo hi
+    for ((x = 0; x < cols; x++)); do
+        if [ "${cols}" -gt 1 ]; then
+            val=$(( x * 65535 / (cols - 1) ))
+        else
+            val=0
+        fi
+        lo=$(( val & 0xFF ))
+        hi=$(( (val >> 8) & 0xFF ))
+        row_seq+=$(printf '\\x%02x\\x%02x' "${lo}" "${hi}")
+    done
+
+    local full_seq=""
+    local y
+    for ((y = 0; y < rows; y++)); do
+        full_seq+="${row_seq}"
+    done
+
+    # Single binary write via printf %b (no xxd / perl dependency required)
+    printf '%b' "${full_seq}" > "${outfile}"
+}
 
 # ── Helper: create a DICOM file from attributes ─────
 # Args: output_file sop_class_uid sop_instance_uid patient_name patient_id
@@ -84,6 +125,29 @@ create_dicom() {
 (0008,0016) UI =${sop_class_uid}
 (0008,0018) UI [${sop_instance_uid}]
 DUMP
+
+    if [ "${GENERATE_PIXEL_DATA}" = "true" ]; then
+        # Cache the pixel buffer per (rows, cols) — identical bytes for every
+        # instance keeps generation deterministic and avoids repeated work.
+        local pixel_file="${TMPDIR}/pixels_${PIXEL_DATA_ROWS}x${PIXEL_DATA_COLS}.bin"
+        if [ ! -s "${pixel_file}" ]; then
+            generate_pixel_data_file "${PIXEL_DATA_ROWS}" "${PIXEL_DATA_COLS}" "${pixel_file}"
+        fi
+
+        cat >> "${dump_file}" << PIXDUMP
+
+# Image Pixel Module
+(0028,0002) US 1
+(0028,0004) CS [MONOCHROME2]
+(0028,0010) US ${PIXEL_DATA_ROWS}
+(0028,0011) US ${PIXEL_DATA_COLS}
+(0028,0100) US 16
+(0028,0101) US 16
+(0028,0102) US 15
+(0028,0103) US 0
+(7FE0,0010) OW =${pixel_file}
+PIXDUMP
+    fi
 
     dump2dcm "${dump_file}" "${output_file}" 2>/dev/null
 }

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -113,10 +113,11 @@ run_suite() {
     fi
 }
 
-run_suite "C-ECHO"  "${SCRIPT_DIR}/test-echo.sh"
-run_suite "C-STORE" "${SCRIPT_DIR}/test-store.sh"
-run_suite "C-FIND"  "${SCRIPT_DIR}/test-find.sh"
-run_suite "C-MOVE"  "${SCRIPT_DIR}/test-move.sh"
+run_suite "C-ECHO"    "${SCRIPT_DIR}/test-echo.sh"
+run_suite "C-STORE"   "${SCRIPT_DIR}/test-store.sh"
+run_suite "C-FIND"    "${SCRIPT_DIR}/test-find.sh"
+run_suite "C-MOVE"    "${SCRIPT_DIR}/test-move.sh"
+run_suite "PixelData" "${SCRIPT_DIR}/test-pixeldata.sh"
 
 # ── Final Summary ─────────────────────────────────────
 echo ""

--- a/tests/test-pixeldata.sh
+++ b/tests/test-pixeldata.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -uo pipefail
+
+# Synthetic PixelData smoke test.
+# Verifies that when GENERATE_PIXEL_DATA=true is in effect for the test data
+# generator, every CT/MR/CR instance carries a non-empty (7FE0,0010) PixelData
+# element AND can be rendered by dcm2pnm without error. The whole suite is
+# skipped (with a clear log line, exit 0) when the flag is unset so the
+# default-behavior path of the project keeps passing CI unchanged.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/test-helpers.sh"
+
+# ── Configuration ─────────────────────────────────────
+TEST_DATA_DIR="${TEST_DATA_DIR:-/dicom/testdata}"
+GENERATE_PIXEL_DATA="${GENERATE_PIXEL_DATA:-false}"
+
+print_header "PixelData Smoke Test"
+
+# ── Skip path: feature is opt-in ──────────────────────
+if [ "${GENERATE_PIXEL_DATA}" != "true" ]; then
+    print_skip "PixelData: GENERATE_PIXEL_DATA is not 'true' (skipping smoke test)"
+    print_summary "PixelData"
+    exit 0
+fi
+
+# ── Ensure data is present ────────────────────────────
+if [ ! -d "${TEST_DATA_DIR}" ] || \
+   [ "$(find "${TEST_DATA_DIR}" -name '*.dcm' 2>/dev/null | wc -l)" -eq 0 ]; then
+    print_fail "PixelData: no .dcm files in ${TEST_DATA_DIR}"
+    print_summary "PixelData"
+    exit 1
+fi
+
+# ── Helper: assert PixelData present in a file ────────
+assert_pixeldata_present() {
+    local label="$1"
+    local file="$2"
+
+    TEST_TOTAL=$((TEST_TOTAL + 1))
+
+    local dump
+    dump=$(dcmdump "${file}" 2>/dev/null) || {
+        print_fail "PixelData: ${label} dcmdump failed (${file})"
+        TEST_FAILED=$((TEST_FAILED + 1))
+        return 1
+    }
+
+    # dcmdump renders PixelData as: (7fe0,0010) OW (PixelData) ...
+    if echo "${dump}" | grep -q '(7fe0,0010)'; then
+        # Confirm it is non-empty by checking the length token is > 0
+        local len
+        len=$(echo "${dump}" | grep '(7fe0,0010)' | head -1 \
+              | sed -nE 's/.*# *([0-9]+).*/\1/p')
+        if [ -n "${len}" ] && [ "${len}" -gt 0 ]; then
+            print_pass "PixelData: ${label} has non-empty (7FE0,0010) [${len} bytes]"
+            TEST_PASSED=$((TEST_PASSED + 1))
+            return 0
+        fi
+    fi
+
+    print_fail "PixelData: ${label} missing or empty (7FE0,0010) (${file})"
+    TEST_FAILED=$((TEST_FAILED + 1))
+    return 1
+}
+
+# ── Helper: assert dcm2pnm renders to a non-empty file ─
+assert_dcm2pnm_renders() {
+    local label="$1"
+    local file="$2"
+
+    TEST_TOTAL=$((TEST_TOTAL + 1))
+
+    local out_pnm
+    out_pnm=$(mktemp --suffix=.pnm)
+    # shellcheck disable=SC2064
+    trap "rm -f '${out_pnm}'" RETURN
+
+    if dcm2pnm "${file}" "${out_pnm}" >/dev/null 2>&1 \
+       && [ -s "${out_pnm}" ]; then
+        local size
+        size=$(stat -c '%s' "${out_pnm}" 2>/dev/null || echo "0")
+        print_pass "PixelData: ${label} rendered by dcm2pnm [${size} bytes PNM]"
+        TEST_PASSED=$((TEST_PASSED + 1))
+        return 0
+    fi
+
+    print_fail "PixelData: ${label} dcm2pnm failed or produced empty output (${file})"
+    TEST_FAILED=$((TEST_FAILED + 1))
+    return 1
+}
+
+# ── Tests ─────────────────────────────────────────────
+for modality in ct mr cr; do
+    sample=$(find "${TEST_DATA_DIR}/${modality}" -name "*.dcm" 2>/dev/null | head -1)
+    if [ -z "${sample}" ]; then
+        print_skip "PixelData: ${modality^^} sample file not found"
+        continue
+    fi
+    assert_pixeldata_present "${modality^^} (first instance)" "${sample}" || true
+    assert_dcm2pnm_renders   "${modality^^} (first instance)" "${sample}" || true
+done
+
+# ── Summary ───────────────────────────────────────────
+print_summary "PixelData"
+[ "${TEST_FAILED}" -eq 0 ]


### PR DESCRIPTION
Closes #2

## What

Add an optional pathway in `scripts/generate-test-data.sh` to embed a deterministic 16-bit MONOCHROME2 `(7FE0,0010) PixelData` element in every CT/MR/CR test instance, controlled by a new `GENERATE_PIXEL_DATA` env flag (default `false` — current behavior is unchanged).

### Change Type
- [x] Feature (new opt-in capability)
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation
- [x] Test
- [x] CI

### Affected Components
| Area | Change |
|------|--------|
| `scripts/generate-test-data.sh` | New `generate_pixel_data_file` helper; `create_dicom` conditionally appends Image Pixel Module + PixelData |
| `env.default` | New `GENERATE_PIXEL_DATA=false` (commented `PIXEL_DATA_ROWS`/`COLS` overrides) |
| `docker-compose.yml` | Pass `GENERATE_PIXEL_DATA`/`PIXEL_DATA_ROWS`/`PIXEL_DATA_COLS` to `pacs-server` and `test-client` |
| `README.md` | Env-var table extended; new "Synthetic PixelData (optional)" section |
| `tests/test-pixeldata.sh` | New smoke test (auto-skips when flag unset) |
| `tests/test-all.sh` | Register PixelData suite |
| `.github/workflows/test-isolation.yml` | New `test-pixeldata` job runs the smoke test + test-find + test-move under `GENERATE_PIXEL_DATA=true` |

## Why

The existing synthetic data only carries metadata, so it exercises the DICOM **network layer** (C-STORE/FIND/MOVE) but cannot validate any **image-pipeline** code (decode, window/level, render). Adjacent projects in the workspace (`dicom_viewer`, `pacs_bridge`) need actual pixel content to test end-to-end. A 64×64 16-bit gradient adds usable pixels at near-zero storage cost and keeps the default off so the existing CI surface is unchanged.

## How

### Implementation
1. `generate_pixel_data_file` builds a horizontal gradient (`val = x * 65535 / (cols - 1)`) as 16-bit little-endian, written via `printf '%b'` so no extra container tools (xxd/perl) are required.
2. The buffer is cached per `(rows, cols)` in `TMPDIR` and imported into every dump file via dump2dcm's `=filename` external-file syntax — the same mechanism the script already uses for SOP Class UIDs.
3. `create_dicom` appends the Image Pixel Module (`Rows`, `Columns`, `BitsAllocated`, `BitsStored`, `HighBit`, `PixelRepresentation`, `SamplesPerPixel`, `PhotometricInterpretation`) plus `(7FE0,0010) OW =<file>` only when `GENERATE_PIXEL_DATA=true`.

### Acceptance Criteria (from #2)
- [x] CT/MR/CR test files include valid PixelData when `GENERATE_PIXEL_DATA=true` — verified by `test-pixeldata.sh` (`assert_pixeldata_present` per modality).
- [x] `dcmdump` shows non-empty PixelData for generated files — `assert_pixeldata_present` parses the dump length token and asserts `> 0`.
- [x] Files are still recognized by `findscu` and `movescu` — new CI job runs `test-find.sh` + `test-move.sh` after enabling the flag.
- [x] `dcm2pnm` (or equivalent) renders the synthetic image without errors — `assert_dcm2pnm_renders` per modality.
- [x] Default behavior is unchanged (no PixelData when the var is unset) — existing matrix jobs (`test-echo`/`store`/`find`/`move`) keep running with the default-off flag.

### Test Plan for Reviewers

```bash
# Default behavior (unchanged)
cp env.default .env
docker compose up -d --build
./pacs.sh test                 # all suites pass; PixelData suite SKIPs

# With PixelData enabled
docker compose down -v
sed -i 's/^GENERATE_PIXEL_DATA=false/GENERATE_PIXEL_DATA=true/' .env
docker compose up -d --force-recreate
docker compose exec test-client /tests/test-pixeldata.sh
docker compose exec test-client dcmdump /dicom/testdata/ct/ct_pat001_1.dcm | grep -E 'PixelData|Rows|Columns'
```

### Local Verification (already performed)
- Bash syntax: `bash -n` clean for all three modified/new scripts.
- Function-level: `generate_pixel_data_file` produces exactly `rows*cols*2` bytes for 64×64 / 2×8 / 1×1; output is byte-identical across runs (deterministic); 8-step hex dump confirms the gradient `0x0000 ... 0xFFFF` matches the formula.

### Breaking Changes
None — flag defaults to `false`, all existing test suites and CI jobs continue to pass.