### PR TITLE
fix(test-data): CT PixelRepresentation must be signed per DICOM CT Image IOD

### DIFF
--- a/scripts/generate-test-data.sh
+++ b/scripts/generate-test-data.sh
@@ -134,6 +134,18 @@ DUMP
             generate_pixel_data_file "${PIXEL_DATA_ROWS}" "${PIXEL_DATA_COLS}" "${pixel_file}"
         fi
 
+        # Per DICOM PS3.3 C.8.2.1, the CT Image Module requires
+        # PixelRepresentation=1 (signed two's complement) and RescaleIntercept/
+        # RescaleSlope (both Type 1) so stored values map to Hounsfield Units.
+        # MR and CR keep the unsigned representation and emit no Rescale tags,
+        # so their dump output stays byte-identical to the pre-fix baseline.
+        local pix_rep="0"
+        local rescale_tags=""
+        if [ "${modality}" = "CT" ]; then
+            pix_rep="1"
+            rescale_tags=$'\n(0028,1052) DS [-1024]\n(0028,1053) DS [1.0]\n(0028,1054) LO [HU]'
+        fi
+
         cat >> "${dump_file}" << PIXDUMP
 
 # Image Pixel Module
@@ -144,7 +156,7 @@ DUMP
 (0028,0100) US 16
 (0028,0101) US 16
 (0028,0102) US 15
-(0028,0103) US 0
+(0028,0103) US ${pix_rep}${rescale_tags}
 (7FE0,0010) OW =${pixel_file}
 PIXDUMP
     fi

--- a/tests/test-pixeldata.sh
+++ b/tests/test-pixeldata.sh
@@ -273,14 +273,57 @@ assert_pixel_range() {
     return 1
 }
 
+# ── Helper: assert CT-specific Rescale tags (PS3.3 C.8.2.1) ─
+# CT IOD requires RescaleIntercept (Type 1), RescaleSlope (Type 1) and
+# RescaleType (Type 1C). MR and CR do not carry these tags, so this
+# helper is invoked only from the CT branch of the test loop.
+# Args: LABEL FILE EXP_INTERCEPT EXP_SLOPE EXP_TYPE
+assert_ct_rescale() {
+    local label="$1"
+    local file="$2"
+    local exp_intercept="$3"
+    local exp_slope="$4"
+    local exp_type="$5"
+
+    TEST_TOTAL=$((TEST_TOTAL + 1))
+
+    local dump
+    dump=$(dcmdump "${file}" 2>/dev/null) || {
+        print_fail "PixelData: ${label} dcmdump failed (${file})"
+        TEST_FAILED=$((TEST_FAILED + 1))
+        return 1
+    }
+
+    local got_intercept got_slope got_type
+    got_intercept=$(grep -m1 '(0028,1052) DS' <<<"${dump}" | sed -nE 's/.*\[([^]]*)\].*/\1/p' | sed 's/[[:space:]]*$//')
+    got_slope=$(grep    -m1 '(0028,1053) DS' <<<"${dump}" | sed -nE 's/.*\[([^]]*)\].*/\1/p' | sed 's/[[:space:]]*$//')
+    got_type=$(grep     -m1 '(0028,1054) LO' <<<"${dump}" | sed -nE 's/.*\[([^]]*)\].*/\1/p' | sed 's/[[:space:]]*$//')
+
+    local errors=()
+    [ "${got_intercept}" = "${exp_intercept}" ] || errors+=("RescaleIntercept expected=${exp_intercept} got=${got_intercept:-<empty>}")
+    [ "${got_slope}"     = "${exp_slope}" ]     || errors+=("RescaleSlope expected=${exp_slope} got=${got_slope:-<empty>}")
+    [ "${got_type}"      = "${exp_type}" ]      || errors+=("RescaleType expected=${exp_type} got=${got_type:-<empty>}")
+
+    if [ "${#errors[@]}" -eq 0 ]; then
+        print_pass "PixelData: ${label} CT rescale tags match (intercept=${got_intercept} slope=${got_slope} type=${got_type})"
+        TEST_PASSED=$((TEST_PASSED + 1))
+        return 0
+    fi
+
+    print_fail "PixelData: ${label} CT rescale mismatch: $(IFS=' | '; echo "${errors[*]}")"
+    TEST_FAILED=$((TEST_FAILED + 1))
+    return 1
+}
+
 # ── Per-modality expected-value table ─────────────────
 # Single source of truth for attribute values. Subsequent issues update
 # rows here without modifying the assertion functions:
-#   #12 (CT signed/Rescale)  -> CT row pix_rep flips 0 -> 1
+#   #12 (CT signed/Rescale)  -> CT pix_rep is now 1; CT-only Rescale tags
+#                                are asserted via assert_ct_rescale below.
 #   #13 (modality-realistic) -> all rows get distinct rows/cols/bits_stored
 # Format: rows cols bits_stored pix_rep photometric
 declare -A PIXEL_EXPECTED=(
-    [ct]="64 64 16 0 MONOCHROME2"
+    [ct]="64 64 16 1 MONOCHROME2"
     [mr]="64 64 16 0 MONOCHROME2"
     [cr]="64 64 16 0 MONOCHROME2"
 )
@@ -308,6 +351,11 @@ for modality in ct mr cr; do
             "${exp_rows}" "${exp_cols}" "${exp_bs}" "${exp_pr}" "${exp_pm}" || true
         assert_file_valid         "${label}" "${sample}" || true
         assert_dcm2pnm_dimensions "${label}" "${sample}" "${exp_rows}" "${exp_cols}" || true
+
+        # CT-only: verify the Rescale tags required by PS3.3 C.8.2.1.
+        if [ "${modality}" = "ct" ]; then
+            assert_ct_rescale "${label}" "${sample}" "-1024" "1.0" "HU" || true
+        fi
 
         # Opt-in slow-path range assertion. Range stays wide (full uint16) until
         # #13 narrows per-modality value ranges.


### PR DESCRIPTION
Closes #12

## Summary

Fix two semantic defects in CT files emitted by `scripts/generate-test-data.sh`
that violate DICOM PS3.3 C.8.2.1 (CT Image Module):

1. `(0028,0103)` PixelRepresentation flipped from `0` (unsigned) to `1` (signed two's complement)
2. `(0028,1052)` RescaleIntercept = `-1024`, `(0028,1053)` RescaleSlope = `1.0`, `(0028,1054)` RescaleType = `HU` added (RescaleIntercept and RescaleSlope are Type 1; RescaleType is Type 1C and emitted alongside them)

Real CT viewers (Horos, OsiriX, RadiAnt, Weasis) require these tags to convert
stored values to Hounsfield Units. Without them, air voxels render as bright
white instead of black and the histogram is unusable for window/level. PR #10
shipped the same Image Pixel Module for all modalities, which is what produced
this regression.

## Approach

Option A from the issue: a `${modality} = "CT"` branch inside the existing
PixelData here-doc block, populating two shell variables (`pix_rep`,
`rescale_tags`) that get substituted directly into the dump file template.

For non-CT paths, `pix_rep="0"` and `rescale_tags=""`, so the line
`(0028,0103) US ${pix_rep}${rescale_tags}` substitutes to exactly
`(0028,0103) US 0` — the same byte sequence as the pre-fix baseline. **MR and
CR dump output is byte-identical** to before.

For CT, `rescale_tags` begins with `\n` so the three new tags land on their
own lines between PixelRepresentation and PixelData.

## Test changes (table-driven, per the #11 contract)

- `PIXEL_EXPECTED[ct]` row's `pix_rep` flips `0 → 1` (now matches the new generator output).
- New `assert_ct_rescale` helper checks `(0028,1052)`, `(0028,1053)`, `(0028,1054)` per PS3.3 C.8.2.1. Invoked only when `modality=ct` so MR and CR (which carry no Rescale tags) are unaffected.
- The 5-column `PIXEL_EXPECTED` table format is preserved; CT-specific tags live in their own helper rather than widening the table — this keeps #13's per-modality refactor easier.

## Acceptance Criteria

- [x] `(0028,0103)` PixelRepresentation is `1` for all CT files
- [x] `(0028,1052)` RescaleIntercept = `-1024` for all CT files
- [x] `(0028,1053)` RescaleSlope = `1.0` for all CT files
- [x] MR and CR files are byte-identical to current output (no regression on other modalities)
- [x] `tests/test-pixeldata.sh` (with #11's table-driven assertions) verifies all three CT changes
- [ ] `dcmdump` output for a generated CT file shows correct PixelRepresentation and Rescale tags (verified by CI)
- [ ] CI passes (existing 7 checks + #11's new attribute assertions + new CT rescale assertion)

## Test Plan

```bash
# Default path (auto-skip preserved)
docker compose exec test-client /tests/test-pixeldata.sh
# Expect: SKIP and exit 0

# Opt-in path
GENERATE_PIXEL_DATA=true docker compose up -d --force-recreate pacs-server
docker compose exec test-client /tests/test-pixeldata.sh
# Expect: CT runs 6 assertions (2 existing + 3 always-on attribute + 1 CT rescale) all PASS;
# MR and CR run 5 assertions each (no CT rescale call) all PASS.

# Spot-check the CT dump
docker compose exec test-client dcmdump /dicom/testdata/ct/ct_pat001_1.dcm | grep -E '(0028,0103)|(0028,1052)|(0028,1053)|(0028,1054)'
# Expect: PixelRep=1, Intercept=-1024, Slope=1.0, Type=HU
```

## Notes

- `bash -n` syntax check passes for both files.
- Diff: +63 / -3 across `scripts/generate-test-data.sh` (+13) and `tests/test-pixeldata.sh` (+50).
- Built on top of #11 (merged in #14) — the table-driven assertions land first per the dependency chain in the original tracking issues.
