### PR TITLE
fix(pacs): harden echo and PixelData profile checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+Dockerfile text eol=lf

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A unified CLI script wraps all common operations:
 | `./pacs.sh shell` | Interactive bash into test-client container |
 | `./pacs.sh reset` | Wipe volumes and restart fresh |
 | `./pacs.sh clean` | Remove all containers, images, and volumes |
-| `./pacs.sh echo [host] [port]` | Quick C-ECHO connectivity check |
+| `./pacs.sh echo [host] [port] [called-ae] [calling-ae]` | Quick C-ECHO connectivity check |
 | `./pacs.sh help` | Show usage with examples |
 
 All `docker compose` commands still work directly if you prefer.
@@ -104,6 +104,9 @@ docker compose down -v
 ```bash
 # Quick check via pacs.sh (auto-detects host/container)
 ./pacs.sh echo localhost 11112
+
+# Check secondary PACS by overriding the Called AE Title
+./pacs.sh echo localhost 11113 DCMTK_PAC2
 
 # From test-client container
 docker compose exec test-client \
@@ -431,6 +434,7 @@ dcmtk_docker/
 ├── scripts/
 │   ├── entrypoint.sh                   # Role-based startup dispatcher
 │   ├── generate-test-data.sh           # Synthetic DICOM generation
+│   ├── pixel-data-profile.sh           # Shared PixelData profile defaults
 │   └── wait-for-pacs.sh               # Readiness polling
 ├── data/
 │   └── dicom-templates/                # dump2dcm reference templates
@@ -442,13 +446,16 @@ dcmtk_docker/
 │   ├── test-store.sh                   # C-STORE tests
 │   ├── test-find.sh                    # C-FIND tests
 │   ├── test-move.sh                    # C-MOVE tests
+│   ├── test-pixeldata.sh               # PixelData smoke tests
+│   ├── test-helpers.sh                 # Shared test helpers
 │   └── test-all.sh                     # Full test suite runner
 └── docs/
     ├── 01_research_dcmtk_dicom.md
     ├── 02_research_docker_approaches.md
     ├── 03_architecture_design.md
     ├── 04_work_plan.md
-    └── 05_usage_guide.md
+    ├── 05_usage_guide.md
+    └── 06_dcmqridx_behavior.md
 ```
 
 ## Troubleshooting
@@ -469,8 +476,8 @@ dcmtk_docker/
 # Check PACS logs
 ./pacs.sh logs pacs-server
 
-# Test TCP connectivity
-docker compose exec test-client nc -zv pacs-server 11112
+# Test DICOM connectivity
+docker compose exec test-client echoscu -aet TEST_SCU -aec DCMTK_PACS pacs-server 11112
 ```
 
 ### C-MOVE fails / "No matching destination"
@@ -478,7 +485,7 @@ docker compose exec test-client nc -zv pacs-server 11112
 C-MOVE requires the destination AE to be registered in the PACS HostTable.
 
 1. **Check the HostTable**: `docker compose exec pacs-server cat /tmp/dcmqrscp.cfg`
-2. **Verify the destination is reachable**: `docker compose exec test-client echoscu storescp-receiver 11112`
+2. **Verify the destination is reachable**: `docker compose exec test-client echoscu -aet TEST_SCU -aec STORE_SCP storescp-receiver 11112`
 3. **Destination AE must match**: The `-aem` value in `movescu` must match a HostTable entry
 
 ### "No such SOP Class" / Transfer syntax errors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     networks:
       - dicom-net
     healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "11112"]
+      test: ["CMD-SHELL", "echoscu -aet HEALTHCHECK -aec $$AE_TITLE localhost 11112"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/docs/03_architecture_design.md
+++ b/docs/03_architecture_design.md
@@ -231,7 +231,7 @@ ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 | Host Port | 11112 |
 | Services | C-ECHO, C-STORE, C-FIND, C-MOVE |
 | Storage | `pacs-data` named volume |
-| Health Check | `echoscu localhost 11112` |
+| Health Check | `echoscu -aec $AE_TITLE localhost 11112` |
 
 #### pacs-server-2 (Secondary PACS)
 
@@ -243,7 +243,7 @@ ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 | Host Port | 11113 |
 | Services | C-ECHO, C-STORE, C-FIND, C-MOVE |
 | Storage | `pacs2-data` named volume |
-| Health Check | `echoscu localhost 11112` |
+| Health Check | `echoscu -aec $AE_TITLE localhost 11112` |
 
 Note: AE Title is `DCMTK_PAC2` (not `DCMTK_PACS2`) because DICOM AE Titles
 have a 16-character maximum limit.
@@ -258,7 +258,7 @@ have a 16-character maximum limit.
 | Host Port | 11114 |
 | Services | C-ECHO (implicit), C-STORE |
 | Storage | `received-data` named volume |
-| Health Check | TCP check on port 11112 |
+| Health Check | `echoscu -aet HEALTHCHECK -aec $AE_TITLE localhost 11112` |
 
 #### test-client (SCU Tools)
 
@@ -458,24 +458,25 @@ All tunable parameters are exposed as environment variables with sensible defaul
 |----------|---------|-------------|
 | `GENERATE_TEST_DATA` | `true` | Generate synthetic DICOM data on startup |
 | `TEST_DATA_DIR` | `/dicom/testdata` | Output directory for generated data |
-| `OID_ROOT` | `1.2.826.0.1.3680043.8.1055` | Private OID root for test UIDs |
+| `OID_ROOT` | `1.2.826.0.1.3680043.8.499` | Private OID root for test UIDs |
 
-### .env File
+### Environment Defaults
 
-The `.env` file provides defaults for all Docker Compose variables:
+The `env.default` file provides defaults for all Docker Compose variables.
+Copy it to `.env` only when local overrides are needed:
 
 ```env
 # PACS Server 1
 PACS1_AE_TITLE=DCMTK_PACS
-PACS1_PORT=11112
+PACS1_HOST_PORT=11112
 
 # PACS Server 2
 PACS2_AE_TITLE=DCMTK_PAC2
-PACS2_PORT=11113
+PACS2_HOST_PORT=11113
 
 # Store SCP Receiver
 STORESCP_AE_TITLE=STORE_SCP
-STORESCP_PORT=11114
+STORESCP_HOST_PORT=11114
 
 # Test Client
 TEST_SCU_AE_TITLE=TEST_SCU
@@ -487,13 +488,13 @@ LOG_LEVEL=info
 GENERATE_TEST_DATA=true
 ```
 
-### dcmqrscp Configuration Template
+### dcmqrscp Configuration Templates
 
-The `dcmqrscp.cfg.template` file uses shell variable placeholders processed by
-`envsubst` or `sed` at container startup:
+The `dcmqrscp-primary.cfg.template` and `dcmqrscp-secondary.cfg.template` files
+use shell variable placeholders processed by `envsubst` at container startup:
 
 ```
-# dcmqrscp.cfg — Generated from template
+# dcmqrscp.cfg - Generated from template
 NetworkTCPPort  = ${DICOM_PORT}
 MaxPDUSize      = ${MAX_PDU_SIZE}
 MaxAssociations = ${MAX_ASSOCIATIONS}
@@ -517,9 +518,9 @@ AETable END
 The entrypoint script processes the template before starting dcmqrscp:
 
 ```bash
-envsubst < /etc/dcmtk/dcmqrscp.cfg.template > /tmp/dcmqrscp.cfg
+envsubst < "${CONFIG_TEMPLATE}" > /tmp/dcmqrscp.cfg
 mkdir -p "${STORAGE_DIR}/${AE_TITLE}"
-exec dcmqrscp -v -c /tmp/dcmqrscp.cfg "$DICOM_PORT"
+exec dcmqrscp --log-level "${DCMTK_LOG_LEVEL}" -c /tmp/dcmqrscp.cfg "$DICOM_PORT"
 ```
 
 ---
@@ -546,13 +547,13 @@ No external datasets are downloaded — everything is self-contained.
 All test UIDs use a private OID root to prevent collision with real clinical data:
 
 ```
-Root:   1.2.826.0.1.3680043.8.1055
+Root:   1.2.826.0.1.3680043.8.499
 Format: {root}.{patient}.{study}.{series}.{instance}
 
 Examples:
-  Study:    1.2.826.0.1.3680043.8.1055.1.1          (patient 1, study 1)
-  Series:   1.2.826.0.1.3680043.8.1055.1.1.1        (patient 1, study 1, series 1)
-  Instance: 1.2.826.0.1.3680043.8.1055.1.1.1.1      (... instance 1)
+  Study:    1.2.826.0.1.3680043.8.499.1.1          (patient 1, study 1)
+  Series:   1.2.826.0.1.3680043.8.499.1.1.1        (patient 1, study 1, series 1)
+  Instance: 1.2.826.0.1.3680043.8.499.1.1.1.1      (... instance 1)
 ```
 
 ### Generation Flow
@@ -564,9 +565,11 @@ Container Start
     │       │
     │       ├── Run generate-test-data.sh
     │       │       │
-    │       │       ├── Create dump files from templates
+    │       │       ├── Create dump files from attributes
     │       │       ├── dump2dcm → .dcm files in /dicom/testdata/
-    │       │       └── storescu → send to local dcmqrscp
+    │       │       └── optional PixelData from profile defaults
+    │       │
+    │       ├── dcmqridx → register .dcm files in the PACS index
     │       │
     │       └── Start dcmqrscp
     │
@@ -596,17 +599,19 @@ dcmtk_docker/
 ├── Dockerfile                        # Single image: debian:bookworm-slim + DCMTK 3.6.7
 ├── docker-compose.yml                # 4 services: pacs-server, pacs-server-2,
 │                                     #   storescp-receiver, test-client
-├── .env                              # Default environment variables
+├── env.default                       # Default environment values (copy to .env)
 ├── .dockerignore                     # Exclude docs, .git, etc. from build context
 ├── README.md                         # Usage guide, quick start, examples
 │
 ├── config/                           # Configuration files (bind-mounted read-only)
-│   ├── dcmqrscp.cfg.template        # dcmqrscp config with variable placeholders
-│   └── dcmqrscp-pacs2.cfg.template  # Config template for secondary PACS
+│   ├── dcmqrscp-primary.cfg.template   # Primary PACS config template
+│   ├── dcmqrscp-secondary.cfg.template # Secondary PACS config template
+│   └── dcmqrscp-production.cfg.example # Production-safe whitelist example
 │
 ├── scripts/                          # Container scripts (copied into image)
 │   ├── entrypoint.sh                # Role-based startup dispatcher
 │   ├── generate-test-data.sh        # Synthetic DICOM file generation
+│   ├── pixel-data-profile.sh        # Shared PixelData profile defaults
 │   └── wait-for-pacs.sh             # Readiness polling script
 │
 ├── data/                             # Test data (bind-mounted into test-client)
@@ -620,13 +625,17 @@ dcmtk_docker/
 │   ├── test-store.sh                # C-STORE archival test
 │   ├── test-find.sh                 # C-FIND query test
 │   ├── test-move.sh                 # C-MOVE retrieval test
+│   ├── test-pixeldata.sh            # PixelData smoke test
+│   ├── test-helpers.sh              # Shared test helpers
 │   └── test-all.sh                  # Run all tests in sequence
 │
 └── docs/                             # Documentation (not in Docker image)
     ├── 01_research_dcmtk_dicom.md   # DCMTK & DICOM protocol research
     ├── 02_research_docker_approaches.md  # Docker approaches research
     ├── 03_architecture_design.md    # This document
-    └── 04_work_plan.md              # Implementation work plan
+    ├── 04_work_plan.md              # Implementation work plan
+    ├── 05_usage_guide.md            # Usage guide
+    └── 06_dcmqridx_behavior.md      # dcmqridx indexing behavior
 ```
 
 ### File Purposes
@@ -635,11 +644,13 @@ dcmtk_docker/
 |------|---------|
 | `Dockerfile` | Builds the unified DCMTK image with all tools and scripts |
 | `docker-compose.yml` | Defines 4 services, network, and volumes |
-| `.env` | Default values for all configurable parameters |
+| `env.default` | Default values for all configurable parameters |
 | `.dockerignore` | Keeps build context small (excludes docs, .git, data) |
-| `config/dcmqrscp.cfg.template` | dcmqrscp configuration with `envsubst` variables |
+| `config/dcmqrscp-primary.cfg.template` | Primary dcmqrscp configuration with `envsubst` variables |
+| `config/dcmqrscp-secondary.cfg.template` | Secondary dcmqrscp configuration with `envsubst` variables |
 | `scripts/entrypoint.sh` | Reads `ROLE` env var, processes config templates, starts service |
 | `scripts/generate-test-data.sh` | Creates synthetic DICOM files from templates using `dump2dcm` |
+| `scripts/pixel-data-profile.sh` | Resolves shared PixelData profile dimension defaults |
 | `scripts/wait-for-pacs.sh` | Polls a PACS with `echoscu` until it responds (used in depends_on) |
 | `data/dicom-templates/*.dump` | dump2dcm input templates for CT, MR, CR modalities |
 | `tests/test-*.sh` | Individual DICOM operation test scripts |

--- a/pacs.sh
+++ b/pacs.sh
@@ -48,6 +48,50 @@ ensure_env() {
     fi
 }
 
+read_env_value() {
+    local key="$1"
+    local default="$2"
+    local value="${!key:-}"
+
+    if [ -n "${value}" ]; then
+        printf '%s' "${value}"
+        return 0
+    fi
+
+    local file
+    for file in .env env.default; do
+        if [ -f "${file}" ]; then
+            value=$(awk -F= -v key="${key}" '
+                { sub(/\r$/, "") }
+                $0 ~ /^[[:space:]]*#/ { next }
+                {
+                    lhs = $1
+                    gsub(/^[[:space:]]+|[[:space:]]+$/, "", lhs)
+                }
+                lhs == key {
+                    sub(/^[^=]*=/, "")
+                    gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+                    print
+                    exit
+                }
+            ' "${file}")
+            if [ -n "${value}" ]; then
+                printf '%s' "${value}"
+                return 0
+            fi
+        fi
+    done
+
+    printf '%s' "${default}"
+}
+
+is_loopback_host() {
+    case "$1" in
+        localhost|127.0.0.1|::1) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 wait_healthy() {
     local timeout="${1:-90}"
     local elapsed=0
@@ -227,11 +271,36 @@ cmd_clean() {
 cmd_echo() {
     local host="${1:-localhost}"
     local port="${2:-11112}"
+    local called_ae="${3:-}"
+    local calling_ae="${4:-}"
+    local pacs1_ae pacs2_ae storescp_ae
+    local pacs1_host_port pacs2_host_port storescp_host_port internal_port
+
+    pacs1_ae=$(read_env_value "PACS1_AE_TITLE" "DCMTK_PACS")
+    pacs2_ae=$(read_env_value "PACS2_AE_TITLE" "DCMTK_PAC2")
+    storescp_ae=$(read_env_value "STORESCP_AE_TITLE" "STORE_SCP")
+    pacs1_host_port=$(read_env_value "PACS1_HOST_PORT" "11112")
+    pacs2_host_port=$(read_env_value "PACS2_HOST_PORT" "11113")
+    storescp_host_port=$(read_env_value "STORESCP_HOST_PORT" "11114")
+    internal_port=$(read_env_value "DICOM_PORT" "11112")
+
+    if [ -z "${called_ae}" ]; then
+        if is_loopback_host "${host}" && [ "${port}" = "${pacs2_host_port}" ]; then
+            called_ae="${pacs2_ae}"
+        elif is_loopback_host "${host}" && [ "${port}" = "${storescp_host_port}" ]; then
+            called_ae="${storescp_ae}"
+        else
+            called_ae="${pacs1_ae}"
+        fi
+    fi
+    if [ -z "${calling_ae}" ]; then
+        calling_ae=$(read_env_value "TEST_SCU_AE_TITLE" "TEST_SCU")
+    fi
 
     # Try host-side echoscu first
     if command -v echoscu &>/dev/null; then
-        info "C-ECHO to ${host}:${port} (host)"
-        if echoscu "${host}" "${port}"; then
+        info "C-ECHO to ${host}:${port} (host, called AE: ${called_ae}, calling AE: ${calling_ae})"
+        if echoscu -aet "${calling_ae}" -aec "${called_ae}" "${host}" "${port}"; then
             ok "C-ECHO succeeded"
         else
             err "C-ECHO failed"
@@ -246,8 +315,18 @@ cmd_echo() {
             exit 1
         fi
 
-        info "C-ECHO to ${host}:${port} (via test-client container)"
-        if ${DC} exec -T test-client echoscu "${host}" "${port}"; then
+        local target_host="${host}"
+        local target_port="${port}"
+        if is_loopback_host "${host}"; then
+            case "${port}" in
+                "${pacs1_host_port}") target_host="pacs-server"; target_port="${internal_port}" ;;
+                "${pacs2_host_port}") target_host="pacs-server-2"; target_port="${internal_port}" ;;
+                "${storescp_host_port}") target_host="storescp-receiver"; target_port="${internal_port}" ;;
+            esac
+        fi
+
+        info "C-ECHO to ${target_host}:${target_port} (via test-client container, called AE: ${called_ae}, calling AE: ${calling_ae})"
+        if ${DC} exec -T test-client echoscu -aet "${calling_ae}" -aec "${called_ae}" "${target_host}" "${target_port}"; then
             ok "C-ECHO succeeded"
         else
             err "C-ECHO failed"
@@ -272,7 +351,8 @@ ${C_BOLD}Commands:${C_RESET}
   ${C_GREEN}shell${C_RESET}             Open bash in the test-client container
   ${C_GREEN}reset${C_RESET}             Stop, wipe volumes, and restart fresh
   ${C_GREEN}clean${C_RESET}             Remove all containers, images, and volumes
-  ${C_GREEN}echo${C_RESET} [host] [port] Quick C-ECHO verification
+  ${C_GREEN}echo${C_RESET} [host] [port] [called-ae] [calling-ae]
+                    Quick C-ECHO verification
   ${C_GREEN}help${C_RESET}              Show this help message
 
 ${C_BOLD}Examples:${C_RESET}
@@ -280,7 +360,8 @@ ${C_BOLD}Examples:${C_RESET}
   ./pacs.sh test                  # Run all tests
   ./pacs.sh test echo             # Run only C-ECHO tests
   ./pacs.sh logs pacs-server      # Tail primary PACS logs
-  ./pacs.sh echo localhost 11112  # Quick connectivity check
+  ./pacs.sh echo localhost 11112             # Primary PACS C-ECHO
+  ./pacs.sh echo localhost 11113 DCMTK_PAC2  # Secondary PACS C-ECHO
   ./pacs.sh reset                 # Fresh restart with clean data
 
 ${C_BOLD}Services:${C_RESET}

--- a/scripts/generate-test-data.sh
+++ b/scripts/generate-test-data.sh
@@ -11,35 +11,19 @@ OUTPUT_DIR="${1:-${TEST_DATA_DIR:-/dicom/testdata}}"
 OID_ROOT="${OID_ROOT:-1.2.826.0.1.3680043.8.499}"
 GENERATE_PIXEL_DATA="${GENERATE_PIXEL_DATA:-false}"
 
-# PixelData profile selects per-modality default dimensions. Modality-specific
-# overrides (e.g. CT_PIXEL_ROWS) win over the profile default.
-PIXEL_DATA_PROFILE="${PIXEL_DATA_PROFILE:-conservative}"
-case "${PIXEL_DATA_PROFILE}" in
-    realistic)
-        DEFAULT_CT_ROWS=512;  DEFAULT_CT_COLS=512
-        DEFAULT_MR_ROWS=256;  DEFAULT_MR_COLS=256
-        DEFAULT_CR_ROWS=1024; DEFAULT_CR_COLS=1024
-        ;;
-    conservative)
-        DEFAULT_CT_ROWS=128;  DEFAULT_CT_COLS=128
-        DEFAULT_MR_ROWS=128;  DEFAULT_MR_COLS=128
-        DEFAULT_CR_ROWS=224;  DEFAULT_CR_COLS=224
-        ;;
-    *)
-        echo "[generate-test-data] WARNING: unknown PIXEL_DATA_PROFILE='${PIXEL_DATA_PROFILE}', falling back to conservative" >&2
-        DEFAULT_CT_ROWS=128;  DEFAULT_CT_COLS=128
-        DEFAULT_MR_ROWS=128;  DEFAULT_MR_COLS=128
-        DEFAULT_CR_ROWS=224;  DEFAULT_CR_COLS=224
-        PIXEL_DATA_PROFILE="conservative"
-        ;;
-esac
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "${SCRIPT_DIR}/pixel-data-profile.sh" ]; then
+    # shellcheck source=scripts/pixel-data-profile.sh
+    source "${SCRIPT_DIR}/pixel-data-profile.sh"
+elif [ -f /usr/local/bin/pixel-data-profile.sh ]; then
+    # shellcheck source=/usr/local/bin/pixel-data-profile.sh
+    source /usr/local/bin/pixel-data-profile.sh
+else
+    echo "[generate-test-data] ERROR: pixel-data-profile.sh not found" >&2
+    exit 1
+fi
 
-CT_PIXEL_ROWS="${CT_PIXEL_ROWS:-${DEFAULT_CT_ROWS}}"
-CT_PIXEL_COLS="${CT_PIXEL_COLS:-${DEFAULT_CT_COLS}}"
-MR_PIXEL_ROWS="${MR_PIXEL_ROWS:-${DEFAULT_MR_ROWS}}"
-MR_PIXEL_COLS="${MR_PIXEL_COLS:-${DEFAULT_MR_COLS}}"
-CR_PIXEL_ROWS="${CR_PIXEL_ROWS:-${DEFAULT_CR_ROWS}}"
-CR_PIXEL_COLS="${CR_PIXEL_COLS:-${DEFAULT_CR_COLS}}"
+resolve_pixel_data_profile_defaults
 
 # The legacy uniform PIXEL_DATA_ROWS / PIXEL_DATA_COLS introduced by PR #10
 # would silently revert per-modality dimensions to a single shared value, so

--- a/scripts/pixel-data-profile.sh
+++ b/scripts/pixel-data-profile.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Shared PixelData profile defaults for generator and tests.
+# The caller may override per-modality dimensions with {CT,MR,CR}_PIXEL_ROWS
+# and {CT,MR,CR}_PIXEL_COLS after selecting PIXEL_DATA_PROFILE.
+
+resolve_pixel_data_profile_defaults() {
+    PIXEL_DATA_PROFILE="${PIXEL_DATA_PROFILE:-conservative}"
+
+    case "${PIXEL_DATA_PROFILE}" in
+        realistic)
+            DEFAULT_CT_ROWS=512;  DEFAULT_CT_COLS=512
+            DEFAULT_MR_ROWS=256;  DEFAULT_MR_COLS=256
+            DEFAULT_CR_ROWS=1024; DEFAULT_CR_COLS=1024
+            ;;
+        conservative)
+            DEFAULT_CT_ROWS=128;  DEFAULT_CT_COLS=128
+            DEFAULT_MR_ROWS=128;  DEFAULT_MR_COLS=128
+            DEFAULT_CR_ROWS=224;  DEFAULT_CR_COLS=224
+            ;;
+        *)
+            echo "[pixel-data-profile] WARNING: unknown PIXEL_DATA_PROFILE='${PIXEL_DATA_PROFILE}', falling back to conservative" >&2
+            DEFAULT_CT_ROWS=128;  DEFAULT_CT_COLS=128
+            DEFAULT_MR_ROWS=128;  DEFAULT_MR_COLS=128
+            DEFAULT_CR_ROWS=224;  DEFAULT_CR_COLS=224
+            PIXEL_DATA_PROFILE="conservative"
+            ;;
+    esac
+
+    CT_PIXEL_ROWS="${CT_PIXEL_ROWS:-${DEFAULT_CT_ROWS}}"
+    CT_PIXEL_COLS="${CT_PIXEL_COLS:-${DEFAULT_CT_COLS}}"
+    MR_PIXEL_ROWS="${MR_PIXEL_ROWS:-${DEFAULT_MR_ROWS}}"
+    MR_PIXEL_COLS="${MR_PIXEL_COLS:-${DEFAULT_MR_COLS}}"
+    CR_PIXEL_ROWS="${CR_PIXEL_ROWS:-${DEFAULT_CR_ROWS}}"
+    CR_PIXEL_COLS="${CR_PIXEL_COLS:-${DEFAULT_CR_COLS}}"
+}

--- a/tests/test-pixeldata.sh
+++ b/tests/test-pixeldata.sh
@@ -24,6 +24,19 @@ if [ "${GENERATE_PIXEL_DATA}" != "true" ]; then
     exit 0
 fi
 
+if [ -f /usr/local/bin/pixel-data-profile.sh ]; then
+    # shellcheck source=/usr/local/bin/pixel-data-profile.sh
+    source /usr/local/bin/pixel-data-profile.sh
+elif [ -f "${SCRIPT_DIR}/../scripts/pixel-data-profile.sh" ]; then
+    # shellcheck source=../scripts/pixel-data-profile.sh
+    source "${SCRIPT_DIR}/../scripts/pixel-data-profile.sh"
+else
+    echo "ERROR: pixel-data-profile.sh not found" >&2
+    exit 1
+fi
+
+resolve_pixel_data_profile_defaults
+
 # ── Ensure data is present ────────────────────────────
 if [ ! -d "${TEST_DATA_DIR}" ] || \
    [ "$(find "${TEST_DATA_DIR}" -name '*.dcm' 2>/dev/null | wc -l)" -eq 0 ]; then
@@ -326,13 +339,13 @@ assert_ct_rescale() {
 #                                 (conservative profile defaults).
 # Each cell honors the matching {CT,MR,CR}_PIXEL_ROWS/_COLS env override so
 # this test stays aligned when the operator overrides individual modalities.
-# Note: PIXEL_DATA_PROFILE=realistic still requires the operator to also set
-# the per-modality dimension env vars for this test to track the new values.
+# Dimension defaults are resolved by scripts/pixel-data-profile.sh, the same
+# helper used by scripts/generate-test-data.sh.
 # Format: rows cols bits_stored pix_rep photometric
 declare -A PIXEL_EXPECTED=(
-    [ct]="${CT_PIXEL_ROWS:-128} ${CT_PIXEL_COLS:-128} 16 1 MONOCHROME2"
-    [mr]="${MR_PIXEL_ROWS:-128} ${MR_PIXEL_COLS:-128} 12 0 MONOCHROME2"
-    [cr]="${CR_PIXEL_ROWS:-224} ${CR_PIXEL_COLS:-224} 14 0 MONOCHROME2"
+    [ct]="${CT_PIXEL_ROWS} ${CT_PIXEL_COLS} 16 1 MONOCHROME2"
+    [mr]="${MR_PIXEL_ROWS} ${MR_PIXEL_COLS} 12 0 MONOCHROME2"
+    [cr]="${CR_PIXEL_ROWS} ${CR_PIXEL_COLS} 14 0 MONOCHROME2"
 )
 
 # ── Tests ─────────────────────────────────────────────


### PR DESCRIPTION
## What
- Make `pacs.sh echo` send explicit Calling/Called AE titles and infer loopback host-port targets when falling back to `test-client`.
- Share PixelData profile dimension defaults between `generate-test-data.sh` and `test-pixeldata.sh` via `scripts/pixel-data-profile.sh`.
- Replace the `storescp-receiver` TCP-only healthcheck with a DICOM C-ECHO healthcheck.
- Refresh README and architecture docs for current env names, config template names, helper scripts, and `dcmqridx` indexing behavior.
- Add `.gitattributes` to keep shell scripts LF-only for Linux containers.

## Why
The documented quick C-ECHO path could fail when local `echoscu` was unavailable because `localhost` was passed through inside `test-client`. PixelData realistic mode was documented but the smoke test still expected conservative dimensions. The store receiver healthcheck only proved that a TCP port was open, not that the DICOM SCP accepted an association.

## Scope
This PR addresses the low-risk usability/test-alignment/documentation items from #17. It intentionally does not redesign `ensure_clean_pacs` or add production Compose profiles.

## Verification
- `bash -n pacs.sh scripts/entrypoint.sh scripts/generate-test-data.sh scripts/pixel-data-profile.sh scripts/wait-for-pacs.sh tests/test-all.sh tests/test-echo.sh tests/test-store.sh tests/test-find.sh tests/test-move.sh tests/test-helpers.sh tests/test-pixeldata.sh`
- `docker compose config -q`
- `git diff --cached --check`
- `docker compose up -d --build --force-recreate`
- `bash pacs.sh echo localhost 11112`
- `bash pacs.sh echo localhost 11113`
- `bash pacs.sh echo localhost 11114`
- `bash pacs.sh test echo`
- `bash pacs.sh test` -> 27/27 passed
- `docker compose run --rm -e ROLE=custom -e GENERATE_PIXEL_DATA=true -e PIXEL_DATA_PROFILE=realistic test-client bash -lc 'rm -rf /tmp/pixeldata-realistic && generate-test-data.sh /tmp/pixeldata-realistic && TEST_DATA_DIR=/tmp/pixeldata-realistic GENERATE_PIXEL_DATA=true PIXEL_DATA_PROFILE=realistic /tests/test-pixeldata.sh'` -> 16/16 passed

Note: full test output still shows existing `ensure_clean_pacs` warnings/null-byte warnings. Those are tracked as a separate follow-up concern and are outside this PR's scope.

## Risk
Low. Changes are limited to CLI parameter handling, shared profile defaults, a stronger healthcheck, documentation, and line-ending guardrails for container-executed shell scripts.

Closes #17