### PR TITLE
fix(tests): normalize OID_ROOT defaults across tests and generator

### DIFF
--- a/docs/01_research_dcmtk_dicom.md
+++ b/docs/01_research_dcmtk_dicom.md
@@ -945,6 +945,11 @@ storescu -v +sd +r -aet BULK_SCU -aec PACS_SCP localhost 11112 /dicom/large_data
 
 When you don't have real DICOM images, create synthetic test files:
 
+> Note: the `1.2.826.0.1.3680043.8.1055.*` UIDs below are illustrative
+> research-only examples. The canonical OID root used by this project's
+> generator and tests is `1.2.826.0.1.3680043.8.499` (see `env.default`
+> and `scripts/generate-test-data.sh`).
+
 ```bash
 # Method 1: Create from dump file
 cat > /tmp/test.dump << 'EOF'

--- a/tests/test-find.sh
+++ b/tests/test-find.sh
@@ -13,7 +13,8 @@ PACS_PORT="${PACS_PORT:-11112}"
 PACS_AE="${PACS_AE_TITLE:-DCMTK_PACS}"
 MY_AE="${AE_TITLE:-TEST_SCU}"
 TEST_DATA_DIR="${TEST_DATA_DIR:-/dicom/testdata}"
-OID_ROOT="${OID_ROOT:-1.2.826.0.1.3680043.8.1055}"
+OID_ROOT="${OID_ROOT:-${DEFAULT_OID_ROOT}}"
+print_verbose "OID_ROOT=${OID_ROOT}"
 
 # ── C-FIND test runner ────────────────────────────────
 # Runs findscu and checks that the number of matching UIDs meets the minimum.

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -27,6 +27,12 @@ fi
 # Set by test-all.sh via environment; individual scripts default to off.
 VERBOSE="${VERBOSE:-false}"
 
+# ── Canonical OID root ────────────────────────────────
+# Single source of truth for the test-data OID root. Must match
+# scripts/generate-test-data.sh and env.default so standalone test
+# scripts query the same UIDs that the generator produces.
+DEFAULT_OID_ROOT="1.2.826.0.1.3680043.8.499"
+
 # ── Counters ──────────────────────────────────────────
 TEST_PASSED=0
 TEST_FAILED=0

--- a/tests/test-move.sh
+++ b/tests/test-move.sh
@@ -20,7 +20,8 @@ MY_AE="${AE_TITLE:-TEST_SCU}"
 STORESCP_HOST="${STORESCP_HOST:-storescp-receiver}"
 STORESCP_AE="${STORESCP_AE_TITLE:-STORE_SCP}"
 TEST_DATA_DIR="${TEST_DATA_DIR:-/dicom/testdata}"
-OID_ROOT="${OID_ROOT:-1.2.826.0.1.3680043.8.1055}"
+OID_ROOT="${OID_ROOT:-${DEFAULT_OID_ROOT}}"
+print_verbose "OID_ROOT=${OID_ROOT}"
 
 # ── Preamble: verify required SCPs are reachable ──────
 # Both the source PACS and the storescp-receiver destination must be up


### PR DESCRIPTION
Closes #23

## Summary
- tests/test-find.sh and tests/test-move.sh now default OID_ROOT to the same value as scripts/generate-test-data.sh and env.default (1.2.826.0.1.3680043.8.499). Standalone runs no longer query for .1055 UIDs that the generator never produces.
- Centralized the canonical value as DEFAULT_OID_ROOT in tests/test-helpers.sh (already sourced by both scripts) to prevent future drift.
- Added a verbose-mode log line (via the existing print_verbose helper) that prints the active OID_ROOT, so misconfiguration is visible when VERBOSE=true.
- Annotated docs/01_research_dcmtk_dicom.md so the remaining ...1055 UIDs in the sample DICOM dump are clearly marked as illustrative research-only examples.

## Scope
- Change test-find.sh and test-move.sh default OID_ROOT to match generate-test-data.sh and env.default.
- Centralize the default in a shared test helper (test-helpers.sh) to avoid future drift.
- Add a verbose-mode log line in tests that prints the active OID_ROOT.
- Review docs for any stale ...1055 examples; annotate the research-doc occurrences as research-only.

## Test Plan
- bash -n tests/test-find.sh tests/test-move.sh tests/test-helpers.sh (clean).
- grep -rn '1.2.826.0.1.3680043.8' . confirms all runtime defaults are .499; the only remaining .1055 references are in docs/01_research_dcmtk_dicom.md and are now explicitly annotated as research-only.
- CI test-isolation workflow validates the integration path.