### PR TITLE
fix(compose): wait for all SCP services before tests

### DIFF
--- a/.github/workflows/test-isolation.yml
+++ b/.github/workflows/test-isolation.yml
@@ -51,19 +51,32 @@ jobs:
           # Give services a moment to settle past their start_period
           sleep 5
 
-      - name: Wait for primary PACS to be healthy
+      - name: Wait for all SCP services to be healthy
         run: |
+          services="pacs-server pacs-server-2 storescp-receiver"
           for i in $(seq 1 60); do
-            status=$(docker inspect -f '{{.State.Health.Status}}' pacs-server 2>/dev/null || echo "starting")
-            if [ "$status" = "healthy" ]; then
-              echo "pacs-server is healthy"
+            pending=""
+            for svc in $services; do
+              status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$svc" 2>/dev/null || echo "starting")
+              if [ "$status" != "healthy" ]; then
+                pending="$pending $svc=$status"
+              fi
+            done
+            if [ -z "$pending" ]; then
+              echo "All SCP services are healthy"
               exit 0
             fi
-            echo "waiting for pacs-server (attempt $i/60, status=$status)"
+            echo "waiting for SCP services (attempt $i/60, pending:$pending)"
             sleep 2
           done
-          echo "ERROR: pacs-server did not become healthy in time"
-          docker compose logs pacs-server
+          echo "ERROR: not all SCP services became healthy in time"
+          for svc in $services; do
+            status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$svc" 2>/dev/null || echo "missing")
+            if [ "$status" != "healthy" ]; then
+              echo "=== $svc not healthy (status: $status); logs ==="
+              docker compose logs --tail=100 "$svc" || true
+            fi
+          done
           exit 1
 
       - name: Run ${{ matrix.test }} in isolation
@@ -105,18 +118,32 @@ jobs:
           docker compose up -d --build
           sleep 5
 
-      - name: Wait for primary PACS to be healthy
+      - name: Wait for all SCP services to be healthy
         run: |
+          services="pacs-server pacs-server-2 storescp-receiver"
           for i in $(seq 1 60); do
-            status=$(docker inspect -f '{{.State.Health.Status}}' pacs-server 2>/dev/null || echo "starting")
-            if [ "$status" = "healthy" ]; then
-              echo "pacs-server is healthy"
+            pending=""
+            for svc in $services; do
+              status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$svc" 2>/dev/null || echo "starting")
+              if [ "$status" != "healthy" ]; then
+                pending="$pending $svc=$status"
+              fi
+            done
+            if [ -z "$pending" ]; then
+              echo "All SCP services are healthy"
               exit 0
             fi
+            echo "waiting for SCP services (attempt $i/60, pending:$pending)"
             sleep 2
           done
-          echo "ERROR: pacs-server did not become healthy in time"
-          docker compose logs pacs-server
+          echo "ERROR: not all SCP services became healthy in time"
+          for svc in $services; do
+            status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$svc" 2>/dev/null || echo "missing")
+            if [ "$status" != "healthy" ]; then
+              echo "=== $svc not healthy (status: $status); logs ==="
+              docker compose logs --tail=100 "$svc" || true
+            fi
+          done
           exit 1
 
       - name: Run test-pixeldata.sh
@@ -152,18 +179,32 @@ jobs:
           docker compose up -d --build
           sleep 5
 
-      - name: Wait for primary PACS to be healthy
+      - name: Wait for all SCP services to be healthy
         run: |
+          services="pacs-server pacs-server-2 storescp-receiver"
           for i in $(seq 1 60); do
-            status=$(docker inspect -f '{{.State.Health.Status}}' pacs-server 2>/dev/null || echo "starting")
-            if [ "$status" = "healthy" ]; then
-              echo "pacs-server is healthy"
+            pending=""
+            for svc in $services; do
+              status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$svc" 2>/dev/null || echo "starting")
+              if [ "$status" != "healthy" ]; then
+                pending="$pending $svc=$status"
+              fi
+            done
+            if [ -z "$pending" ]; then
+              echo "All SCP services are healthy"
               exit 0
             fi
+            echo "waiting for SCP services (attempt $i/60, pending:$pending)"
             sleep 2
           done
-          echo "ERROR: pacs-server did not become healthy in time"
-          docker compose logs pacs-server
+          echo "ERROR: not all SCP services became healthy in time"
+          for svc in $services; do
+            status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$svc" 2>/dev/null || echo "missing")
+            if [ "$status" != "healthy" ]; then
+              echo "=== $svc not healthy (status: $status); logs ==="
+              docker compose logs --tail=100 "$svc" || true
+            fi
+          done
           exit 1
 
       - name: First test-store.sh run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,10 @@ services:
     depends_on:
       pacs-server:
         condition: service_healthy
+      pacs-server-2:
+        condition: service_healthy
+      storescp-receiver:
+        condition: service_healthy
 
 networks:
   dicom-net:

--- a/pacs.sh
+++ b/pacs.sh
@@ -33,6 +33,7 @@ fi
 
 # ── Service definitions ──────────────────────────
 ALL_SERVICES=(pacs-server pacs-server-2 storescp-receiver test-client)
+SCP_SERVICES=(pacs-server pacs-server-2 storescp-receiver)
 VALID_TESTS=(all echo store find move)
 
 # ── Helper functions ─────────────────────────────
@@ -92,25 +93,34 @@ is_loopback_host() {
     esac
 }
 
-wait_healthy() {
-    local timeout="${1:-90}"
+wait_for_services() {
+    # Wait for the given services to report healthy. Dumps the health status
+    # and recent logs of any service that does not become ready in time.
+    # Usage: wait_for_services <timeout_seconds> <service> [service ...]
+    local timeout="$1"
+    shift
+    local services=("$@")
+
+    if [ "${#services[@]}" -eq 0 ]; then
+        services=("${SCP_SERVICES[@]}")
+    fi
+
     local elapsed=0
     local interval=3
-    info "Waiting for services to be healthy (timeout: ${timeout}s)..."
+    info "Waiting for services to be healthy: ${services[*]} (timeout: ${timeout}s)..."
 
     while [ "${elapsed}" -lt "${timeout}" ]; do
-        local all_healthy=true
-        for svc in pacs-server pacs-server-2 storescp-receiver; do
-            local health
-            health=$(docker inspect --format='{{.State.Health.Status}}' "${svc}" 2>/dev/null || echo "missing")
+        local pending=()
+        local svc health
+        for svc in "${services[@]}"; do
+            health=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${svc}" 2>/dev/null || echo "missing")
             if [ "${health}" != "healthy" ]; then
-                all_healthy=false
-                break
+                pending+=("${svc}")
             fi
         done
 
-        if [ "${all_healthy}" = true ]; then
-            ok "All services are healthy"
+        if [ "${#pending[@]}" -eq 0 ]; then
+            ok "All required services are healthy"
             return 0
         fi
 
@@ -118,7 +128,15 @@ wait_healthy() {
         elapsed=$((elapsed + interval))
     done
 
-    warn "Timeout waiting for healthy status after ${timeout}s"
+    err "Timeout waiting for healthy status after ${timeout}s"
+    for svc in "${services[@]}"; do
+        local health
+        health=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${svc}" 2>/dev/null || echo "missing")
+        if [ "${health}" != "healthy" ]; then
+            warn "Service ${svc} is not healthy (status: ${health}); recent logs:"
+            ${DC} logs --tail=50 "${svc}" 2>&1 || true
+        fi
+    done
     return 1
 }
 
@@ -165,7 +183,7 @@ cmd_up() {
     info "Building and starting all services..."
     ${DC} up -d --build
 
-    if wait_healthy 90; then
+    if wait_for_services 90 "${SCP_SERVICES[@]}"; then
         print_status_table
     else
         warn "Some services may not be ready yet. Check with: ./pacs.sh status"
@@ -215,6 +233,13 @@ cmd_test() {
     state=$(docker inspect --format='{{.State.Status}}' test-client 2>/dev/null || echo "not found")
     if [ "${state}" != "running" ]; then
         err "test-client container is not running. Start with: ./pacs.sh up"
+        exit 1
+    fi
+
+    # Defense in depth: ensure every SCP the tests rely on is healthy before
+    # invoking the test entry points (issue #20).
+    if ! wait_for_services 60 "${SCP_SERVICES[@]}"; then
+        err "Required SCP services are not healthy; aborting test run."
         exit 1
     fi
 


### PR DESCRIPTION
Closes #20

## Summary
- Extend test-client depends_on to require pacs-server-2 and storescp-receiver health, not just pacs-server.
- Refactor pacs.sh wait_healthy into wait_for_services accepting an explicit service list, and call it from both up and test so test invocations also block on every required SCP.
- Replace the single pacs-server health gate in each test-isolation job with a loop covering all three SCPs, dumping recent logs of any service that does not become ready.

## Scope
- Shared readiness strategy across pacs-server, pacs-server-2, and storescp-receiver.
- Strategy used in pacs.sh up, pacs.sh test, and every job in .github/workflows/test-isolation.yml.
- depends_on health conditions added for the services test-client needs; standalone test preambles in tests/test-*.sh remain as defense in depth.
- Timeout failures keep printing actionable health status and recent logs of the service that did not become ready.

## Test Plan
- bash -n on modified scripts
- CI test-isolation workflow validates the integration path