### PR TITLE
fix(cli): pacs.sh test and logs argument forwarding

### DIFF
--- a/pacs.sh
+++ b/pacs.sh
@@ -193,7 +193,14 @@ cmd_status() {
 }
 
 cmd_test() {
-    local suite="${1:-all}"
+    # If the first arg looks like an option (starts with '-'), treat the suite
+    # as the default 'all' and forward every arg to the test script. Otherwise
+    # consume exactly one positional arg as the suite name.
+    local suite="all"
+    if [ "$#" -gt 0 ] && [ "${1#-}" = "$1" ]; then
+        suite="$1"
+        shift
+    fi
 
     # Validate suite name
     local valid=false
@@ -225,14 +232,19 @@ cmd_test() {
         script="/tests/test-${suite}.sh"
     fi
 
-    shift 2>/dev/null || true
     info "Running test suite: ${suite}"
     ${DC} exec -T test-client bash "${script}" "$@"
 }
 
 cmd_logs() {
-    local service="${1:-}"
-    shift 2>/dev/null || true
+    # Only consume the first arg as a service name when it doesn't start with
+    # '-'. This preserves docker compose log options such as --tail, --since,
+    # and --timestamps when no service is specified.
+    local service=""
+    if [ "$#" -gt 0 ] && [ "${1#-}" = "$1" ]; then
+        service="$1"
+        shift
+    fi
 
     if [ -n "${service}" ]; then
         ${DC} logs -f "${service}" "$@"


### PR DESCRIPTION
Closes #24

## Summary
- pacs.sh cmd_test and cmd_logs now correctly forward trailing args.

## Scope
- Audit argument handling in pacs.sh after the top-level command shift.
- Make cmd_test consume only the suite argument (when positional) and pass remaining flags to the test script.
- Make cmd_logs consume only an actual service name (no leading dash) and preserve Docker Compose log options.
- Document the forwarding contract inline in both subcommands.

## Implementation
- Detect option-style args via `${1#-}` parameter expansion: if removing the leading `-` does not change the value, the arg is positional and is consumed as the suite or service name; otherwise it is left in `$@` to be forwarded to the underlying command.
- Removes the unconditional `shift` that previously swallowed an option when no positional was supplied.

## Test Plan
- bash -n pacs.sh (passes)
- Manual trace: ./pacs.sh test all --verbose now expands to docker compose exec -T test-client bash /tests/test-all.sh --verbose
- Manual trace: ./pacs.sh test echo --verbose now expands to docker compose exec -T test-client bash /tests/test-echo.sh --verbose
- Manual trace: ./pacs.sh test --verbose (no suite) now defaults to all and forwards --verbose
- Manual trace: ./pacs.sh logs pacs-server --tail 50 expands to docker compose logs -f pacs-server --tail 50
- Manual trace: ./pacs.sh logs --tail 50 (no service) forwards --tail 50 to docker compose logs -f
- CI test-isolation workflow validates the integration path