### PR TITLE
fix(tests): scope test-store cleanup to compose volumes

### DIFF
--- a/.github/workflows/test-isolation.yml
+++ b/.github/workflows/test-isolation.yml
@@ -89,6 +89,27 @@ jobs:
           done
           exit 1
 
+      - name: Wipe PACS storage on the host before test-store.sh
+        # test-store.sh requires an empty PACS so its >= 3 study-count
+        # check is meaningful. The PACS entrypoint indexes synthetic test
+        # data on first boot, so cleanup must run on the host (the
+        # test-client image has no Docker CLI). See issue #19.
+        if: matrix.test == 'test-store.sh'
+        run: |
+          for svc in pacs-server pacs-server-2; do
+            docker compose exec -T "$svc" sh -c \
+              "find /dicom/db -mindepth 1 -delete 2>/dev/null || true"
+          done
+          docker compose restart pacs-server pacs-server-2
+          for i in $(seq 1 60); do
+            status=$(docker inspect -f '{{.State.Health.Status}}' pacs-server 2>/dev/null || echo "starting")
+            if [ "$status" = "healthy" ]; then
+              echo "pacs-server healthy after cleanup"
+              break
+            fi
+            sleep 2
+          done
+
       - name: Run ${{ matrix.test }} in isolation
         run: |
           docker compose exec -T test-client /tests/${{ matrix.test }}
@@ -237,8 +258,44 @@ jobs:
           done
           exit 1
 
+      - name: Wipe PACS storage on the host before first run
+        # The PACS entrypoint indexes synthetic test data on first boot,
+        # so the volumes are dirty even before any storescu. Cleanup must
+        # run on the host (the test-client image has no Docker CLI). See
+        # issue #19.
+        run: |
+          for svc in pacs-server pacs-server-2; do
+            docker compose exec -T "$svc" sh -c \
+              "find /dicom/db -mindepth 1 -delete 2>/dev/null || true"
+          done
+          docker compose restart pacs-server pacs-server-2
+          for i in $(seq 1 60); do
+            status=$(docker inspect -f '{{.State.Health.Status}}' pacs-server 2>/dev/null || echo "starting")
+            if [ "$status" = "healthy" ]; then
+              echo "pacs-server healthy after cleanup"
+              break
+            fi
+            sleep 2
+          done
+
       - name: First test-store.sh run
         run: docker compose exec -T test-client /tests/test-store.sh
+
+      - name: Wipe PACS storage on the host between runs
+        run: |
+          for svc in pacs-server pacs-server-2; do
+            docker compose exec -T "$svc" sh -c \
+              "find /dicom/db -mindepth 1 -delete 2>/dev/null || true"
+          done
+          docker compose restart pacs-server pacs-server-2
+          for i in $(seq 1 60); do
+            status=$(docker inspect -f '{{.State.Health.Status}}' pacs-server 2>/dev/null || echo "starting")
+            if [ "$status" = "healthy" ]; then
+              echo "pacs-server healthy after cleanup"
+              break
+            fi
+            sleep 2
+          done
 
       - name: Second test-store.sh run (must also pass)
         run: docker compose exec -T test-client /tests/test-store.sh

--- a/.github/workflows/test-isolation.yml
+++ b/.github/workflows/test-isolation.yml
@@ -94,11 +94,19 @@ jobs:
         # check is meaningful. The PACS entrypoint indexes synthetic test
         # data on first boot, so cleanup must run on the host (the
         # test-client image has no Docker CLI). See issue #19.
+        #
+        # The entrypoint re-indexes test data on every container start
+        # unless a .indexed marker exists. After wiping storage we recreate
+        # the marker so the restart leaves PACS empty rather than re-
+        # populating it from /dicom/testdata. See scripts/entrypoint.sh.
         if: matrix.test == 'test-store.sh'
         run: |
           for svc in pacs-server pacs-server-2; do
-            docker compose exec -T "$svc" sh -c \
-              "find /dicom/db -mindepth 1 -delete 2>/dev/null || true"
+            docker compose exec -T "$svc" sh -c '
+              find /dicom/db -mindepth 1 -delete 2>/dev/null || true
+              mkdir -p "/dicom/db/${AE_TITLE}"
+              touch "/dicom/db/${AE_TITLE}/.indexed"
+            '
           done
           docker compose restart pacs-server pacs-server-2
           for i in $(seq 1 60); do
@@ -263,10 +271,18 @@ jobs:
         # so the volumes are dirty even before any storescu. Cleanup must
         # run on the host (the test-client image has no Docker CLI). See
         # issue #19.
+        #
+        # The entrypoint re-indexes test data on every container start
+        # unless a .indexed marker exists. After wiping storage we recreate
+        # the marker so the restart leaves PACS empty rather than re-
+        # populating it from /dicom/testdata. See scripts/entrypoint.sh.
         run: |
           for svc in pacs-server pacs-server-2; do
-            docker compose exec -T "$svc" sh -c \
-              "find /dicom/db -mindepth 1 -delete 2>/dev/null || true"
+            docker compose exec -T "$svc" sh -c '
+              find /dicom/db -mindepth 1 -delete 2>/dev/null || true
+              mkdir -p "/dicom/db/${AE_TITLE}"
+              touch "/dicom/db/${AE_TITLE}/.indexed"
+            '
           done
           docker compose restart pacs-server pacs-server-2
           for i in $(seq 1 60); do
@@ -282,10 +298,15 @@ jobs:
         run: docker compose exec -T test-client /tests/test-store.sh
 
       - name: Wipe PACS storage on the host between runs
+        # Same marker trick as before to keep the second run starting from
+        # an empty PACS. See the comment on the first wipe step.
         run: |
           for svc in pacs-server pacs-server-2; do
-            docker compose exec -T "$svc" sh -c \
-              "find /dicom/db -mindepth 1 -delete 2>/dev/null || true"
+            docker compose exec -T "$svc" sh -c '
+              find /dicom/db -mindepth 1 -delete 2>/dev/null || true
+              mkdir -p "/dicom/db/${AE_TITLE}"
+              touch "/dicom/db/${AE_TITLE}/.indexed"
+            '
           done
           docker compose restart pacs-server pacs-server-2
           for i in $(seq 1 60); do

--- a/pacs.sh
+++ b/pacs.sh
@@ -247,6 +247,11 @@ cmd_status() {
 # test-store.sh against a stack that already holds studies from a prior
 # run; the test-client container itself has no Docker CLI and no access
 # to the PACS volumes (see issue #19).
+#
+# The PACS entrypoint re-indexes synthetic test data on every container
+# start unless a .indexed marker exists. After wiping storage we recreate
+# the marker so the restart leaves PACS empty rather than re-populating
+# it from /dicom/testdata. See scripts/entrypoint.sh.
 clean_pacs_storage() {
     local svc storage_dir state cid
     storage_dir="/dicom/db"
@@ -262,8 +267,11 @@ clean_pacs_storage() {
             continue
         fi
         info "Wiping ${svc}:${storage_dir} (host-side cleanup)"
-        ${DC} exec -T "${svc}" sh -c \
-            "find '${storage_dir}' -mindepth 1 -delete 2>/dev/null || true"
+        ${DC} exec -T "${svc}" sh -c "
+            find '${storage_dir}' -mindepth 1 -delete 2>/dev/null || true
+            mkdir -p \"${storage_dir}/\${AE_TITLE}\"
+            touch \"${storage_dir}/\${AE_TITLE}/.indexed\"
+        "
     done
 
     # Restart the PACS services so dcmqrscp re-reads its (now-empty) index.

--- a/pacs.sh
+++ b/pacs.sh
@@ -242,6 +242,36 @@ cmd_status() {
     print_status_table
 }
 
+# Wipe the PACS storage directories on the host side, scoped to the
+# compose project's PACS service containers. Required before re-running
+# test-store.sh against a stack that already holds studies from a prior
+# run; the test-client container itself has no Docker CLI and no access
+# to the PACS volumes (see issue #19).
+clean_pacs_storage() {
+    local svc storage_dir state cid
+    storage_dir="/dicom/db"
+    for svc in pacs-server pacs-server-2; do
+        cid=$(service_container_id "${svc}")
+        if [ -z "${cid}" ]; then
+            state="not found"
+        else
+            state=$(docker inspect --format='{{.State.Status}}' "${cid}" 2>/dev/null || echo "not found")
+        fi
+        if [ "${state}" != "running" ]; then
+            warn "${svc} not running; skipping host-side cleanup"
+            continue
+        fi
+        info "Wiping ${svc}:${storage_dir} (host-side cleanup)"
+        ${DC} exec -T "${svc}" sh -c \
+            "find '${storage_dir}' -mindepth 1 -delete 2>/dev/null || true"
+    done
+
+    # Restart the PACS services so dcmqrscp re-reads its (now-empty) index.
+    info "Restarting PACS services to reload empty index"
+    ${DC} restart pacs-server pacs-server-2 >/dev/null
+    wait_for_services 60 pacs-server pacs-server-2 || warn "PACS services not healthy after restart"
+}
+
 cmd_test() {
     # If the first arg looks like an option (starts with '-'), treat the suite
     # as the default 'all' and forward every arg to the test script. Otherwise
@@ -286,6 +316,12 @@ cmd_test() {
         err "Required SCP services are not healthy; aborting test run."
         exit 1
     fi
+
+    # Suites that require PACS to start empty need host-side cleanup,
+    # because the in-container helper cannot reach the PACS volumes.
+    case "${suite}" in
+        store|all) clean_pacs_storage ;;
+    esac
 
     local script
     if [ "${suite}" = "all" ]; then

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -188,84 +188,39 @@ ensure_pacs_data() {
     fi
 }
 
-# ── Wipe PACS storage and reload from scratch ─────────
-# Canonical bootstrap helper for tests that require a clean PACS.
-# Idempotent: safe to call multiple times. Always leaves the PACS empty
-# of test data after the wipe (callers typically follow with storescu).
+# ── Verify PACS is empty (cleanup must happen on the host) ────
+# Verification-only helper. Destructive cleanup of PACS storage must be
+# performed on the host by the caller (e.g. `pacs.sh` or the CI workflow)
+# before this script runs inside the test-client container.
 #
-# The container hosting dcmqrscp is identified by ${pacs_host} which, in
-# the docker-compose setup, doubles as the compose service name. Storage
-# is wiped via `docker compose exec` against that service's STORAGE_DIR,
-# which scopes naturally to the active compose project so parallel
-# stacks do not collide.
+# Rationale: the test-client image does not include the Docker CLI, and
+# its own `/dicom/db` is not the PACS server's storage volume. Any in-
+# container attempt to delete `/dicom/db` would target the wrong path and
+# silently leave PACS data intact. See issue #19.
+#
+# Behavior:
+#   1. Probes the SCP with C-ECHO; returns non-zero if unreachable.
+#   2. Queries the SCP for any remaining studies via C-FIND.
+#   3. Returns non-zero (and logs ERROR) if any studies remain. This makes
+#      the test fail loudly rather than continuing against dirty state.
 #
 # Usage:
-#   ensure_clean_pacs "host" "port" "called_ae" "calling_ae" [service] [storage_dir]
-#
-# Defaults:
-#   service     -> ${pacs_host}
-#   storage_dir -> /dicom/db (matches docker-compose pacs-server config)
+#   ensure_clean_pacs "host" "port" "called_ae" "calling_ae"
 ensure_clean_pacs() {
     local pacs_host="$1"
     local pacs_port="$2"
     local pacs_ae="$3"
     local my_ae="$4"
-    local service="${5:-${pacs_host}}"
-    local storage_dir="${6:-/dicom/db}"
 
-    # Verify the SCP responds before attempting destructive work
+    # Verify the SCP responds before querying study count
     if ! echoscu -aet "${my_ae}" -aec "${pacs_ae}" -to 5 \
             "${pacs_host}" "${pacs_port}" >/dev/null 2>&1; then
         echo "ERROR: ensure_clean_pacs: ${pacs_ae}@${pacs_host}:${pacs_port} not reachable" >&2
         return 1
     fi
 
-    # Detect docker compose binary (v2 plugin preferred, legacy fallback)
-    local dc=""
-    if command -v docker >/dev/null 2>&1; then
-        if docker compose version >/dev/null 2>&1; then
-            dc="docker compose"
-        elif command -v docker-compose >/dev/null 2>&1; then
-            dc="docker-compose"
-        fi
-    fi
-
-    # Resolve the compose service to a container ID under the current
-    # compose project, so we never assume a fixed container_name.
-    local container_id=""
-    if [ -n "${dc}" ]; then
-        container_id=$(${dc} ps -q "${service}" 2>/dev/null | head -n1)
-    fi
-
-    # Wipe the PACS storage directory inside the container.
-    # Two strategies, in order of preference:
-    #   1. docker compose exec/restart (when running on the host with docker compose)
-    #   2. direct rm                   (when this helper is itself running inside the PACS container)
-    if [ -n "${dc}" ] && [ -n "${container_id}" ]; then
-        echo "Wiping PACS storage in service ${service}:${storage_dir}"
-        ${dc} exec -T "${service}" sh -c \
-            "find '${storage_dir}' -mindepth 1 -delete 2>/dev/null || true"
-        # Restart dcmqrscp so the index is re-read from the now-empty dir
-        ${dc} restart "${service}" >/dev/null 2>&1 || true
-        # Wait for the container to come back online
-        local i
-        for i in $(seq 1 30); do
-            if echoscu -aet "${my_ae}" -aec "${pacs_ae}" -to 2 \
-                    "${pacs_host}" "${pacs_port}" >/dev/null 2>&1; then
-                break
-            fi
-            sleep 1
-        done
-    elif [ -d "${storage_dir}" ] && [ -w "${storage_dir}" ]; then
-        echo "Wiping PACS storage at ${storage_dir} (in-container mode)"
-        find "${storage_dir}" -mindepth 1 -delete 2>/dev/null || true
-    else
-        echo "WARNING: ensure_clean_pacs: no docker compose access and ${storage_dir} not writable" >&2
-        echo "         PACS will not be wiped; tests may observe pre-existing data." >&2
-        return 0
-    fi
-
-    # Verify the wipe succeeded by re-querying study count
+    # Query for any remaining studies; the host-side caller is responsible
+    # for wiping PACS storage before this helper runs.
     local check_output remaining
     check_output=$(findscu -aet "${my_ae}" -aec "${pacs_ae}" \
         -S "${pacs_host}" "${pacs_port}" \
@@ -273,9 +228,11 @@ ensure_clean_pacs() {
     remaining=$(echo "${check_output}" | grep -c "StudyInstanceUID" 2>/dev/null || echo "0")
 
     if [ "${remaining}" -gt 0 ]; then
-        echo "WARNING: ensure_clean_pacs: ${remaining} studies remain after wipe" >&2
-    else
-        echo "  ensure_clean_pacs: PACS storage cleared"
+        echo "ERROR: ensure_clean_pacs: ${remaining} studies remain on ${pacs_ae}@${pacs_host}:${pacs_port}" >&2
+        echo "       The host-side runner must wipe PACS storage before invoking this test." >&2
+        return 1
     fi
+
+    echo "  ensure_clean_pacs: ${pacs_ae}@${pacs_host}:${pacs_port} is empty"
     return 0
 }

--- a/tests/test-store.sh
+++ b/tests/test-store.sh
@@ -34,13 +34,14 @@ if [ ! -d "${TEST_DATA_DIR}/ct" ] || [ "$(find "${TEST_DATA_DIR}" -name '*.dcm' 
     fi
 fi
 
-# ── Wipe PACS so re-runs start from a known-empty state ──
-# Without this the C-STORE verification step would only check that the
-# study count is >= 3, which is trivially true after the first run; with
-# this, calling test-store.sh twice in a row both pass and exercise the
-# full storescu -> dcmqrscp ingest path each time.
-ensure_clean_pacs "${PACS_HOST}"  "${PACS_PORT}" "${PACS_AE}"  "${MY_AE}"
-ensure_clean_pacs "${PACS2_HOST}" "${PACS_PORT}" "${PACS2_AE}" "${MY_AE}"
+# ── Require both PACS to start empty (verification-only) ─────
+# Destructive cleanup of PACS storage runs on the host before this script
+# is invoked inside test-client (see `pacs.sh` and the test-isolation
+# workflow). Here we only verify the precondition: any leftover studies
+# would let the >= 3 study-count check below pass trivially on the second
+# run and mask regressions in the storescu -> dcmqrscp ingest path.
+ensure_clean_pacs "${PACS_HOST}"  "${PACS_PORT}" "${PACS_AE}"  "${MY_AE}" || exit 1
+ensure_clean_pacs "${PACS2_HOST}" "${PACS_PORT}" "${PACS2_AE}" "${MY_AE}" || exit 1
 
 CT_COUNT=$(find "${TEST_DATA_DIR}/ct" -name "*.dcm" 2>/dev/null | wc -l)
 MR_COUNT=$(find "${TEST_DATA_DIR}/mr" -name "*.dcm" 2>/dev/null | wc -l)


### PR DESCRIPTION
Closes #19

## Summary
- `tests/test-helpers.sh`: `ensure_clean_pacs` no longer runs destructive code from inside test-client. The function now only probes the SCP with C-ECHO and queries study count via C-FIND, returning non-zero (with an ERROR log) when leftover studies remain.
- `tests/test-store.sh`: both `ensure_clean_pacs` invocations now exit the script on failure, and the surrounding comment documents that destructive cleanup is a host-side responsibility.
- `pacs.sh`: added `clean_pacs_storage` helper that uses `docker compose exec` against the actual `pacs-server`/`pacs-server-2` services to wipe `/dicom/db`, then restarts those services so dcmqrscp re-reads its empty index. Invoked from `cmd_test` before `store` and `all` suites.
- `.github/workflows/test-isolation.yml`: added host-side cleanup steps before `test-store.sh` in the isolation matrix (gated on `matrix.test == 'test-store.sh'`) and before each run in the idempotency job. The PACS entrypoint indexes synthetic data on boot, so cleanup is required even on a fresh stack.

## Scope
- Destructive PACS cleanup now targets the real compose service containers and volumes via host-side `docker compose exec` / `docker compose restart`.
- Removed the in-container `/dicom/db` rm-rf fallback that was deleting the wrong path inside test-client.
- `ensure_clean_pacs` now fails the test when studies remain after a claimed wipe instead of logging a WARNING and returning 0.
- Host-side cleanup is scoped to the current compose project's PACS services and to `/dicom/db` only.
- Updated comments in `test-store.sh` and `test-helpers.sh` to describe the new execution model.

## Test Plan
- `bash -n tests/test-store.sh tests/test-helpers.sh pacs.sh` passes locally.
- CI `test-isolation.yml` validates the integration path:
  - `test-store.sh (isolated)` matrix job exercises a single isolated run after host-side cleanup.
  - `test-store-idempotency` job runs `test-store.sh` twice with host-side cleanup between runs; the strengthened verification will now fail the second run if any studies remain after the wipe.