### PR TITLE
refactor(compose): drop fixed container_name coupling

### DIFF
--- a/.github/workflows/test-isolation.yml
+++ b/.github/workflows/test-isolation.yml
@@ -57,7 +57,12 @@ jobs:
           for i in $(seq 1 60); do
             pending=""
             for svc in $services; do
-              status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$svc" 2>/dev/null || echo "starting")
+              cid=$(docker compose ps -q "$svc" 2>/dev/null | head -n1)
+              if [ -n "$cid" ]; then
+                status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid" 2>/dev/null || echo "starting")
+              else
+                status="starting"
+              fi
               if [ "$status" != "healthy" ]; then
                 pending="$pending $svc=$status"
               fi
@@ -71,7 +76,12 @@ jobs:
           done
           echo "ERROR: not all SCP services became healthy in time"
           for svc in $services; do
-            status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$svc" 2>/dev/null || echo "missing")
+            cid=$(docker compose ps -q "$svc" 2>/dev/null | head -n1)
+            if [ -n "$cid" ]; then
+              status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid" 2>/dev/null || echo "missing")
+            else
+              status="missing"
+            fi
             if [ "$status" != "healthy" ]; then
               echo "=== $svc not healthy (status: $status); logs ==="
               docker compose logs --tail=100 "$svc" || true
@@ -124,7 +134,12 @@ jobs:
           for i in $(seq 1 60); do
             pending=""
             for svc in $services; do
-              status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$svc" 2>/dev/null || echo "starting")
+              cid=$(docker compose ps -q "$svc" 2>/dev/null | head -n1)
+              if [ -n "$cid" ]; then
+                status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid" 2>/dev/null || echo "starting")
+              else
+                status="starting"
+              fi
               if [ "$status" != "healthy" ]; then
                 pending="$pending $svc=$status"
               fi
@@ -138,7 +153,12 @@ jobs:
           done
           echo "ERROR: not all SCP services became healthy in time"
           for svc in $services; do
-            status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$svc" 2>/dev/null || echo "missing")
+            cid=$(docker compose ps -q "$svc" 2>/dev/null | head -n1)
+            if [ -n "$cid" ]; then
+              status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid" 2>/dev/null || echo "missing")
+            else
+              status="missing"
+            fi
             if [ "$status" != "healthy" ]; then
               echo "=== $svc not healthy (status: $status); logs ==="
               docker compose logs --tail=100 "$svc" || true
@@ -185,7 +205,12 @@ jobs:
           for i in $(seq 1 60); do
             pending=""
             for svc in $services; do
-              status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$svc" 2>/dev/null || echo "starting")
+              cid=$(docker compose ps -q "$svc" 2>/dev/null | head -n1)
+              if [ -n "$cid" ]; then
+                status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid" 2>/dev/null || echo "starting")
+              else
+                status="starting"
+              fi
               if [ "$status" != "healthy" ]; then
                 pending="$pending $svc=$status"
               fi
@@ -199,7 +224,12 @@ jobs:
           done
           echo "ERROR: not all SCP services became healthy in time"
           for svc in $services; do
-            status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$svc" 2>/dev/null || echo "missing")
+            cid=$(docker compose ps -q "$svc" 2>/dev/null | head -n1)
+            if [ -n "$cid" ]; then
+              status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid" 2>/dev/null || echo "missing")
+            else
+              status="missing"
+            fi
             if [ "$status" != "healthy" ]; then
               echo "=== $svc not healthy (status: $status); logs ==="
               docker compose logs --tail=100 "$svc" || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   # Full PACS with C-ECHO, C-STORE, C-FIND, C-MOVE via dcmqrscp
   pacs-server:
     build: .
-    container_name: pacs-server
     environment:
       - ROLE=pacs-server
       - AE_TITLE=${PACS1_AE_TITLE:-DCMTK_PACS}
@@ -49,7 +48,6 @@ services:
   # Second PACS instance for multi-PACS testing scenarios
   pacs-server-2:
     build: .
-    container_name: pacs-server-2
     environment:
       - ROLE=pacs-server
       - AE_TITLE=${PACS2_AE_TITLE:-DCMTK_PAC2}
@@ -85,7 +83,6 @@ services:
   # Lightweight receiver for C-MOVE retrieval testing
   storescp-receiver:
     build: .
-    container_name: storescp-receiver
     environment:
       - ROLE=storescp
       - AE_TITLE=${STORESCP_AE_TITLE:-STORE_SCP}
@@ -110,7 +107,6 @@ services:
   # Interactive container with all DCMTK SCU tools
   test-client:
     build: .
-    container_name: test-client
     environment:
       - ROLE=test-client
       - AE_TITLE=${TEST_SCU_AE_TITLE:-TEST_SCU}

--- a/pacs.sh
+++ b/pacs.sh
@@ -49,6 +49,13 @@ ensure_env() {
     fi
 }
 
+# Resolve a compose service name to its current container ID under the
+# active compose project. Prints the ID on stdout (empty if no container).
+service_container_id() {
+    local service="$1"
+    ${DC} ps -q "${service}" 2>/dev/null | head -n1
+}
+
 read_env_value() {
     local key="$1"
     local default="$2"
@@ -111,9 +118,14 @@ wait_for_services() {
 
     while [ "${elapsed}" -lt "${timeout}" ]; do
         local pending=()
-        local svc health
+        local svc cid health
         for svc in "${services[@]}"; do
-            health=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${svc}" 2>/dev/null || echo "missing")
+            cid=$(service_container_id "${svc}")
+            if [ -z "${cid}" ]; then
+                health="missing"
+            else
+                health=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${cid}" 2>/dev/null || echo "missing")
+            fi
             if [ "${health}" != "healthy" ]; then
                 pending+=("${svc}")
             fi
@@ -130,8 +142,13 @@ wait_for_services() {
 
     err "Timeout waiting for healthy status after ${timeout}s"
     for svc in "${services[@]}"; do
-        local health
-        health=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${svc}" 2>/dev/null || echo "missing")
+        local cid health
+        cid=$(service_container_id "${svc}")
+        if [ -z "${cid}" ]; then
+            health="missing"
+        else
+            health=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${cid}" 2>/dev/null || echo "missing")
+        fi
         if [ "${health}" != "healthy" ]; then
             warn "Service ${svc} is not healthy (status: ${health}); recent logs:"
             ${DC} logs --tail=50 "${svc}" 2>&1 || true
@@ -146,12 +163,19 @@ print_status_table() {
     printf "%-20s %-12s %-14s %-10s\n" "────────────────────" "────────────" "──────────────" "──────────"
 
     for svc in "${ALL_SERVICES[@]}"; do
-        local status ae_title port
+        local status ae_title port cid
+
+        cid=$(service_container_id "${svc}")
 
         # Container status
         local state health
-        state=$(docker inspect --format='{{.State.Status}}' "${svc}" 2>/dev/null || echo "not found")
-        health=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}-{{end}}' "${svc}" 2>/dev/null || echo "-")
+        if [ -z "${cid}" ]; then
+            state="not found"
+            health="-"
+        else
+            state=$(docker inspect --format='{{.State.Status}}' "${cid}" 2>/dev/null || echo "not found")
+            health=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}-{{end}}' "${cid}" 2>/dev/null || echo "-")
+        fi
 
         if [ "${state}" = "running" ] && [ "${health}" = "healthy" ]; then
             status="${C_GREEN}healthy${C_RESET}"
@@ -164,12 +188,20 @@ print_status_table() {
         fi
 
         # AE Title from container env
-        ae_title=$(docker inspect --format='{{range .Config.Env}}{{println .}}{{end}}' "${svc}" 2>/dev/null \
-            | grep '^AE_TITLE=' | cut -d= -f2 || echo "-")
+        if [ -n "${cid}" ]; then
+            ae_title=$(docker inspect --format='{{range .Config.Env}}{{println .}}{{end}}' "${cid}" 2>/dev/null \
+                | grep '^AE_TITLE=' | cut -d= -f2 || echo "-")
+        else
+            ae_title="-"
+        fi
         [ -z "${ae_title}" ] && ae_title="-"
 
         # Host port mapping
-        port=$(docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}}{{range $conf}}{{.HostPort}}{{end}}{{end}}' "${svc}" 2>/dev/null || echo "-")
+        if [ -n "${cid}" ]; then
+            port=$(docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}}{{range $conf}}{{.HostPort}}{{end}}{{end}}' "${cid}" 2>/dev/null || echo "-")
+        else
+            port="-"
+        fi
         [ -z "${port}" ] && port="-"
 
         printf "%-20s %-22b %-14s %-10s\n" "${svc}" "${status}" "${ae_title}" "${port}"
@@ -198,9 +230,9 @@ cmd_down() {
 }
 
 cmd_status() {
-    # Check if any container exists
+    # Check if any container exists for this compose project
     local running
-    running=$(docker ps --filter "name=pacs-server" --filter "name=storescp-receiver" --filter "name=test-client" -q 2>/dev/null | wc -l | tr -d ' ')
+    running=$(${DC} ps -q 2>/dev/null | wc -l | tr -d ' ')
 
     if [ "${running}" -eq 0 ]; then
         warn "No services are running. Start with: ./pacs.sh up"
@@ -236,8 +268,13 @@ cmd_test() {
     fi
 
     # Check if test-client is running
-    local state
-    state=$(docker inspect --format='{{.State.Status}}' test-client 2>/dev/null || echo "not found")
+    local cid state
+    cid=$(service_container_id test-client)
+    if [ -z "${cid}" ]; then
+        state="not found"
+    else
+        state=$(docker inspect --format='{{.State.Status}}' "${cid}" 2>/dev/null || echo "not found")
+    fi
     if [ "${state}" != "running" ]; then
         err "test-client container is not running. Start with: ./pacs.sh up"
         exit 1
@@ -279,8 +316,13 @@ cmd_logs() {
 }
 
 cmd_shell() {
-    local state
-    state=$(docker inspect --format='{{.State.Status}}' test-client 2>/dev/null || echo "not found")
+    local cid state
+    cid=$(service_container_id test-client)
+    if [ -z "${cid}" ]; then
+        state="not found"
+    else
+        state=$(docker inspect --format='{{.State.Status}}' "${cid}" 2>/dev/null || echo "not found")
+    fi
     if [ "${state}" != "running" ]; then
         err "test-client container is not running. Start with: ./pacs.sh up"
         exit 1
@@ -345,8 +387,13 @@ cmd_echo() {
         fi
     else
         # Fallback: use test-client container
-        local state
-        state=$(docker inspect --format='{{.State.Status}}' test-client 2>/dev/null || echo "not found")
+        local cid state
+        cid=$(service_container_id test-client)
+        if [ -z "${cid}" ]; then
+            state="not found"
+        else
+            state=$(docker inspect --format='{{.State.Status}}' "${cid}" 2>/dev/null || echo "not found")
+        fi
         if [ "${state}" != "running" ]; then
             err "No local echoscu and test-client is not running"
             exit 1

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -194,21 +194,23 @@ ensure_pacs_data() {
 # of test data after the wipe (callers typically follow with storescu).
 #
 # The container hosting dcmqrscp is identified by ${pacs_host} which, in
-# the docker-compose setup, doubles as the container_name. Storage is
-# wiped via `docker exec` against that container's STORAGE_DIR.
+# the docker-compose setup, doubles as the compose service name. Storage
+# is wiped via `docker compose exec` against that service's STORAGE_DIR,
+# which scopes naturally to the active compose project so parallel
+# stacks do not collide.
 #
 # Usage:
-#   ensure_clean_pacs "host" "port" "called_ae" "calling_ae" [container_name] [storage_dir]
+#   ensure_clean_pacs "host" "port" "called_ae" "calling_ae" [service] [storage_dir]
 #
 # Defaults:
-#   container_name -> ${pacs_host}
-#   storage_dir    -> /dicom/db (matches docker-compose pacs-server config)
+#   service     -> ${pacs_host}
+#   storage_dir -> /dicom/db (matches docker-compose pacs-server config)
 ensure_clean_pacs() {
     local pacs_host="$1"
     local pacs_port="$2"
     local pacs_ae="$3"
     local my_ae="$4"
-    local container_name="${5:-${pacs_host}}"
+    local service="${5:-${pacs_host}}"
     local storage_dir="${6:-/dicom/db}"
 
     # Verify the SCP responds before attempting destructive work
@@ -218,17 +220,33 @@ ensure_clean_pacs() {
         return 1
     fi
 
+    # Detect docker compose binary (v2 plugin preferred, legacy fallback)
+    local dc=""
+    if command -v docker >/dev/null 2>&1; then
+        if docker compose version >/dev/null 2>&1; then
+            dc="docker compose"
+        elif command -v docker-compose >/dev/null 2>&1; then
+            dc="docker-compose"
+        fi
+    fi
+
+    # Resolve the compose service to a container ID under the current
+    # compose project, so we never assume a fixed container_name.
+    local container_id=""
+    if [ -n "${dc}" ]; then
+        container_id=$(${dc} ps -q "${service}" 2>/dev/null | head -n1)
+    fi
+
     # Wipe the PACS storage directory inside the container.
     # Two strategies, in order of preference:
-    #   1. docker exec (when running on the host with the docker CLI)
-    #   2. direct rm   (when this helper is itself running inside the PACS container)
-    if command -v docker >/dev/null 2>&1 && \
-            docker inspect "${container_name}" >/dev/null 2>&1; then
-        echo "Wiping PACS storage in container ${container_name}:${storage_dir}"
-        docker exec "${container_name}" sh -c \
+    #   1. docker compose exec/restart (when running on the host with docker compose)
+    #   2. direct rm                   (when this helper is itself running inside the PACS container)
+    if [ -n "${dc}" ] && [ -n "${container_id}" ]; then
+        echo "Wiping PACS storage in service ${service}:${storage_dir}"
+        ${dc} exec -T "${service}" sh -c \
             "find '${storage_dir}' -mindepth 1 -delete 2>/dev/null || true"
         # Restart dcmqrscp so the index is re-read from the now-empty dir
-        docker restart "${container_name}" >/dev/null 2>&1 || true
+        ${dc} restart "${service}" >/dev/null 2>&1 || true
         # Wait for the container to come back online
         local i
         for i in $(seq 1 30); do
@@ -242,7 +260,7 @@ ensure_clean_pacs() {
         echo "Wiping PACS storage at ${storage_dir} (in-container mode)"
         find "${storage_dir}" -mindepth 1 -delete 2>/dev/null || true
     else
-        echo "WARNING: ensure_clean_pacs: no docker CLI access and ${storage_dir} not writable" >&2
+        echo "WARNING: ensure_clean_pacs: no docker compose access and ${storage_dir} not writable" >&2
         echo "         PACS will not be wiped; tests may observe pre-existing data." >&2
         return 0
     fi


### PR DESCRIPTION
Closes #21

## Summary
- `docker-compose.yml`: remove the four global `container_name:` fields from `pacs-server`, `pacs-server-2`, `storescp-receiver`, and `test-client`. Internal DICOM hostnames continue to resolve because compose service names still act as in-network DNS aliases.
- `pacs.sh`: add a `service_container_id` helper that calls `docker compose ps -q <service>` and feed the resulting container ID into every `docker inspect` call (`wait_healthy`, `print_status_table`, `cmd_test`, `cmd_shell`, `cmd_echo`). `cmd_status` now uses `${DC} ps -q` so the existence check scopes to the active compose project.
- `tests/test-helpers.sh`: `ensure_clean_pacs` now detects `docker compose`, resolves the service to a container ID, and wipes/restarts via `docker compose exec` / `docker compose restart`. The in-container fallback path (no docker CLI) is unchanged.
- `.github/workflows/test-isolation.yml`: the three `Wait for primary PACS to be healthy` steps resolve `pacs-server` through `docker compose ps -q` before calling `docker inspect`, so they no longer assume a fixed container name.

## Scope
- Remove `container_name` from compose services and rely on compose service names plus project scoping.
- Replace direct `docker inspect <fixed-name>` / `docker restart <fixed-name>` style calls with `docker compose ps -q <service>` lookups or compose-native subcommands (`docker compose exec`, `docker compose restart`).
- Update `pacs.sh status`, `pacs.sh test`, helper-driven cleanup, and the CI workflow's health-wait loops to resolve containers through compose.
- DICOM network hostnames inside the compose network (`pacs-server`, `pacs-server-2`, `storescp-receiver`) are preserved because service DNS names still work without `container_name`.

## Test Plan
- `bash -n pacs.sh`, `bash -n tests/test-helpers.sh`, `bash -n tests/test-store.sh`, `bash -n tests/test-echo.sh` (all pass).
- `docker compose config --quiet` against a freshly staged `.env` (passes).
- CI: the existing `test-isolation` workflow validates the integration path across `test-echo`, `test-store`, `test-find`, `test-move`, `test-pixeldata`, and double-`test-store` (idempotency).