### PR TITLE
fix(dev-env): add data hygiene cleanup policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # DICOM data (generated at runtime)
 data/dicom-output/
 data/received/
+data/ct/
+data/mr/
+data/cr/
 
 # Docker volumes
 volumes/

--- a/README.md
+++ b/README.md
@@ -255,12 +255,28 @@ Synthetic DICOM files are generated automatically at first startup:
 To add custom DICOM files, place them in the `data/` directory.
 They will be available in the test-client at `/dicom/testdata/`.
 
-To regenerate test data, remove existing files and restart:
+#### Source fixtures vs generated artifacts
+
+The `data/` directory mixes two kinds of content. Only the source fixtures are
+tracked in git; generated artifacts are ignored via `.gitignore` and can be
+wiped safely.
+
+| Path | Kind | Tracked | Notes |
+|------|------|---------|-------|
+| `data/dicom-templates/` | Source fixture | Yes | `*.dump` templates consumed by the generator; never delete |
+| `data/ct/`, `data/mr/`, `data/cr/` | Generated | No | Synthetic DICOM written on first `./pacs.sh up` |
+| `data/dicom-output/`, `data/received/` | Generated | No | Test runtime artifacts |
+
+To regenerate test data, remove the generated directories and restart:
 
 ```bash
-rm -rf data/ct data/mr data/cr
+./pacs.sh clean-data            # remove only generated artifacts
 docker compose restart test-client
 ```
+
+`./pacs.sh clean-data --dry-run` prints the paths it would remove without
+touching the filesystem. Source fixtures in `data/dicom-templates/` are
+always preserved.
 
 #### Synthetic PixelData (optional)
 

--- a/pacs.sh
+++ b/pacs.sh
@@ -391,6 +391,60 @@ cmd_clean() {
     ok "Cleaned up all Docker resources"
 }
 
+# Remove host-side generated DICOM data while preserving source fixtures.
+# The test-client bind mounts ./data into /dicom/testdata and writes synthetic
+# CT/MR/CR studies under data/ct, data/mr, data/cr (see issue #37). The
+# data/dicom-templates directory is checked into git and must never be touched.
+#
+# Usage: ./pacs.sh clean-data [--dry-run]
+cmd_clean_data() {
+    local dry_run=false
+    if [ "${1:-}" = "--dry-run" ] || [ "${1:-}" = "-n" ]; then
+        dry_run=true
+    fi
+
+    # Resolve the data directory to an absolute path and refuse to act if it
+    # is missing — guards against running from an unexpected CWD.
+    local data_root="${SCRIPT_DIR}/data"
+    if [ ! -d "${data_root}" ]; then
+        err "data directory not found at ${data_root}"
+        exit 1
+    fi
+
+    # Narrow allowlist of generated subdirectories. Anything not listed here
+    # (notably data/dicom-templates) is left untouched.
+    local generated_dirs=(ct mr cr dicom-output received)
+
+    local removed=0
+    local sub abs
+    for sub in "${generated_dirs[@]}"; do
+        abs="${data_root}/${sub}"
+        if [ ! -e "${abs}" ]; then
+            continue
+        fi
+        # Safety: refuse to delete anything that is not under data_root.
+        case "${abs}" in
+            "${data_root}/"*) ;;
+            *) err "Refusing to remove ${abs}: outside ${data_root}"; exit 1 ;;
+        esac
+        if [ "${dry_run}" = true ]; then
+            info "[dry-run] would remove ${abs}"
+        else
+            info "Removing ${abs}"
+            rm -rf -- "${abs}"
+        fi
+        removed=$((removed + 1))
+    done
+
+    if [ "${removed}" -eq 0 ]; then
+        ok "No generated data to remove"
+    elif [ "${dry_run}" = true ]; then
+        ok "Dry run complete (${removed} path(s) would be removed)"
+    else
+        ok "Removed ${removed} generated data path(s); source fixtures preserved"
+    fi
+}
+
 cmd_echo() {
     local host="${1:-localhost}"
     local port="${2:-11112}"
@@ -479,6 +533,10 @@ ${C_BOLD}Commands:${C_RESET}
   ${C_GREEN}shell${C_RESET}             Open bash in the test-client container
   ${C_GREEN}reset${C_RESET}             Stop, wipe volumes, and restart fresh
   ${C_GREEN}clean${C_RESET}             Remove all containers, images, and volumes
+  ${C_GREEN}clean-data${C_RESET} [--dry-run]
+                    Remove host-side generated DICOM data (data/ct, data/mr,
+                    data/cr, data/dicom-output, data/received); preserves
+                    data/dicom-templates source fixtures
   ${C_GREEN}echo${C_RESET} [host] [port] [called-ae] [calling-ae]
                     Quick C-ECHO verification
   ${C_GREEN}help${C_RESET}              Show this help message
@@ -513,6 +571,7 @@ case "${command}" in
     shell)   cmd_shell "$@" ;;
     reset)   cmd_reset "$@" ;;
     clean)   cmd_clean "$@" ;;
+    clean-data) cmd_clean_data "$@" ;;
     echo)    cmd_echo "$@" ;;
     help|-h|--help) cmd_help ;;
     *)


### PR DESCRIPTION
## What
Add a data hygiene policy so `./pacs.sh up` and the test suites no longer
leave untracked synthetic DICOM in the working tree.

- `.gitignore`: ignore the runtime-generated `data/ct/`, `data/mr/`, `data/cr/`
  alongside the existing `data/dicom-output/` and `data/received/`.
- `pacs.sh`: add `clean-data [--dry-run]` to remove only generated artifacts
  while preserving the `data/dicom-templates/` source fixtures.
- `README.md`: document which paths are source fixtures vs generated artifacts
  and reference the new command.

## Why
`test-client` bind mounts `./data` into `/dicom/testdata` and writes synthetic
CT/MR/CR studies under `data/ct`, `data/mr`, `data/cr`. Without ignoring those
paths, every contributor saw a dirty tree after running tests, and there was
no safe way to wipe generated data without risking the checked-in templates.

## How
- `cmd_clean_data` uses an absolute `${SCRIPT_DIR}/data` root, refuses to act
  if it is missing, and only removes a fixed allowlist of subdirectories
  (`ct`, `mr`, `cr`, `dicom-output`, `received`). `data/dicom-templates/` is
  never in that list.
- Each removal is guarded by a path-prefix check against `data_root` to refuse
  anything outside the project's `data/` directory.
- `--dry-run` (or `-n`) prints the paths without modifying the filesystem.
- The new command is wired into the dispatch table and `cmd_help`. The
  existing `VALID_TESTS` array and other commands are untouched.

## Verification
- `bash -n pacs.sh` -> ok
- Created `data/ct/`, `data/mr/`, `data/cr/` with test files, then ran
  `./pacs.sh clean-data --dry-run` (no filesystem change) and
  `./pacs.sh clean-data` (only the generated dirs removed,
  `data/dicom-templates/` preserved).
- After recreating the generated dirs, `git status --short` shows no
  untracked entries for them, confirming the `.gitignore` rules.

## Scope discipline
- `VALID_TESTS` and other dispatch entries left untouched (shared with #34/#35/#36).
- README change confined to the existing "Test Data" section.
- No drive-by refactors.

Closes #37
