### PR TITLE
feat(pacs): expose pixeldata test suite via cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Then rebuild: `docker compose up -d --build pacs-server`
 ./pacs.sh test store    # Image archival
 ./pacs.sh test find     # Query
 ./pacs.sh test move     # Retrieval
+./pacs.sh test pixeldata  # PixelData smoke (opt-in, see below)
 ```
 
 ### Test Data
@@ -307,6 +308,33 @@ docker compose exec test-client dcmdump /dicom/testdata/ct/ct_pat001_1.dcm | gre
 
 A smoke test that runs `dcm2pnm` against a generated file is included as
 `tests/test-pixeldata.sh` (auto-skipped when `GENERATE_PIXEL_DATA` is unset).
+Run it explicitly through the `pacs.sh` CLI once test data has been generated
+with PixelData embedded:
+
+```bash
+# Wipe stale data, regenerate with conservative profile (default), run smoke test
+rm -rf data/ct data/mr data/cr
+GENERATE_PIXEL_DATA=true docker compose up -d --force-recreate pacs-server test-client
+GENERATE_PIXEL_DATA=true ./pacs.sh test pixeldata
+
+# Same with the realistic profile (larger frames, higher memory/CPU)
+rm -rf data/ct data/mr data/cr
+PIXEL_DATA_PROFILE=realistic GENERATE_PIXEL_DATA=true \
+    docker compose up -d --force-recreate pacs-server test-client
+GENERATE_PIXEL_DATA=true PIXEL_DATA_PROFILE=realistic \
+    ./pacs.sh test pixeldata
+```
+
+When `GENERATE_PIXEL_DATA` is left unset, `./pacs.sh test pixeldata` runs the
+script which prints a `SKIP` line and exits 0 — useful for confirming the CLI
+wiring without regenerating any data. CI currently exercises the conservative
+profile only; the realistic profile remains an opt-in local check.
+
+Re-generating PixelData requires wiping the per-modality `data/ct`, `data/mr`,
+and `data/cr` directories so the test-client recreates them on next start. The
+PACS storage volume also caches a `<storage>/<AE_TITLE>/.indexed` marker (see
+note below) — delete it whenever the underlying instances change so the server
+re-indexes them.
 
 > **Note:** The `pacs-server` indexes test DICOM files into its database on
 > first startup and writes a marker file at `<storage>/<AE_TITLE>/.indexed`

--- a/pacs.sh
+++ b/pacs.sh
@@ -34,7 +34,7 @@ fi
 # ── Service definitions ──────────────────────────
 ALL_SERVICES=(pacs-server pacs-server-2 storescp-receiver test-client)
 SCP_SERVICES=(pacs-server pacs-server-2 storescp-receiver)
-VALID_TESTS=(all echo store find move)
+VALID_TESTS=(all echo store find move pixeldata)
 
 # ── Helper functions ─────────────────────────────
 info()  { printf "${C_CYAN}>>>${C_RESET} %s\n" "$*"; }


### PR DESCRIPTION
## What

Expose the existing `tests/test-pixeldata.sh` smoke suite as a first-class
`./pacs.sh test pixeldata` invocation so developers can run the PixelData
verification path without invoking the helper script directly.

### Change Type
- [x] Feature (new CLI entry point + documentation)

### Affected Components
- `pacs.sh` — register `pixeldata` in `VALID_TESTS`
- `README.md` — document the new suite + conservative / realistic recipes

## Why

`tests/test-pixeldata.sh` already exists, but it is not listed in the
`VALID_TESTS` dispatcher and is not mentioned in the README. Running
`./pacs.sh test pixeldata` today exits with `Unknown test suite`, forcing
contributors to invoke `docker compose exec test-client bash
/tests/test-pixeldata.sh` by hand. The default-data path also keeps the
suite silent (`GENERATE_PIXEL_DATA=false`), so the smoke test is invisible
unless the operator already knows it exists.

### Related Issues
- Closes #36

## How

1. Append `pixeldata` to `VALID_TESTS` in `pacs.sh` so the existing generic
   dispatch (`/tests/test-${suite}.sh`) routes the call. No new case block
   is required — the suite does not need the `clean_pacs_storage`
   pre-step the `store`/`all` suites use.
2. Add a `pixeldata` row to the "Run Individual Tests" snippet in
   `README.md`, with an inline pointer to the opt-in description below.
3. Extend the "Synthetic PixelData (optional)" section with explicit
   conservative- and realistic-profile invocation examples that re-create
   the test data, refresh the `test-client`, and call
   `./pacs.sh test pixeldata`.
4. Document the `<storage>/<AE_TITLE>/.indexed` marker and per-modality
   `data/ct`, `data/mr`, `data/cr` wipe requirement so users know how to
   re-generate the dataset cleanly.
5. CI policy: keep the conservative profile as the implicit CI path
   (already exercised by `tests/test-all.sh` semantics); realistic
   profile stays opt-in to avoid CPU/memory regressions. This is stated
   in the README; no workflow change is included in this PR.

### Verification
- `bash -n pacs.sh tests/*.sh` — passes for `pacs.sh` and all 7 test
  scripts in `tests/`.
- `./pacs.sh test pixeldata` without `GENERATE_PIXEL_DATA=true` is
  expected to print a `SKIP` line and exit 0 (gated path in the
  pre-existing `tests/test-pixeldata.sh`).
- A full `GENERATE_PIXEL_DATA=true ./pacs.sh test pixeldata` run was not
  executed in this PR; the underlying script already lands tested in
  earlier PRs and this change is a CLI wiring + documentation change.

### Breaking Changes
- None. Existing `./pacs.sh test {all,echo,store,find,move}` invocations
  are unchanged.

### Rollback
- Revert the two-file diff; no schema / volume / data migration.
