### PR TITLE
fix(tests): stabilize c-find response counting

### DIFF
--- a/tests/test-find.sh
+++ b/tests/test-find.sh
@@ -24,12 +24,15 @@ run_find_test() {
     shift 2
     TEST_TOTAL=$((TEST_TOTAL + 1))
 
+    # Capture findscu output stripped of NUL bytes so `ignored null byte`
+    # warnings from shell variable assignment do not appear in test logs.
     local output
-    output=$("$@" 2>&1 || true)
+    output=$("$@" 2>&1 | tr -d '\0' || true)
 
-    # Count UID lines in the response — each matching record contains a UID
+    # Count UID lines from response datasets (excluding the verbose
+    # request-key echo). See count_find_responses in test-helpers.sh.
     local uid_count
-    uid_count=$(echo "${output}" | grep -c "StudyInstanceUID\|SeriesInstanceUID\|SOPInstanceUID" 2>/dev/null || echo "0")
+    uid_count=$(count_find_responses "${output}")
 
     if [ "${uid_count}" -ge "${expected_min}" ]; then
         print_pass "C-FIND: ${description} (found ${uid_count}, expected >= ${expected_min})"
@@ -139,13 +142,8 @@ NEG_OUTPUT=$(findscu -v -aet "${MY_AE}" -aec "${PACS_AE}" \
     -S "${PACS_HOST}" "${PACS_PORT}" \
     -k QueryRetrieveLevel=STUDY \
     -k PatientID="NONEXISTENT" \
-    -k StudyInstanceUID 2>&1 || true)
-# Verbose findscu echoes the empty request key as
-# "(0020,000d) UI (no value available) ... StudyInstanceUID"
-# which would otherwise inflate the count even when zero studies match.
-# Use "|| true" instead of "|| echo 0" so a zero match (grep -vc exit 1)
-# does not append a second "0" to the captured value and break -eq.
-NEG_COUNT=$(echo "${NEG_OUTPUT}" | grep "StudyInstanceUID" | grep -vc "no value available" || true)
+    -k StudyInstanceUID 2>&1 | tr -d '\0' || true)
+NEG_COUNT=$(count_find_responses "${NEG_OUTPUT}" StudyInstanceUID)
 if [ "${NEG_COUNT}" -eq 0 ]; then
     print_pass "C-FIND: nonexistent patient returns 0 results"
     TEST_PASSED=$((TEST_PASSED + 1))

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -134,6 +134,52 @@ run_test_expect_fail() {
     fi
 }
 
+# ── C-FIND response counting ──────────────────────────
+# Count UID lines from a `findscu -v` capture that belong to response
+# datasets (not the request key echo).
+#
+# Verbose findscu prints each request key once before the association,
+# typically as
+#   (0020,000d) UI (no value available)         #   0, 1 StudyInstanceUID
+# and then prints one response dataset per match, where the same tag
+# carries an actual UID value. Counting bare "StudyInstanceUID"
+# occurrences therefore inflates the result by exactly one per request
+# key. Filtering out lines that contain "no value available" leaves only
+# response datasets.
+#
+# The helper also strips NUL bytes from the captured output. `findscu`
+# can emit raw DICOM bytes on stderr when servers misbehave, which makes
+# shell `grep` warn `ignored null byte in input` and pollutes the test
+# log.
+#
+# Output: a single non-negative integer on stdout, nothing else.
+#
+# Usage: count_find_responses "<findscu -v output>" [tag1 tag2 ...]
+#   When no tags are supplied the default set covers the three common
+#   query-retrieve level UIDs.
+count_find_responses() {
+    local output="$1"
+    shift
+    local tags=("$@")
+    if [ "${#tags[@]}" -eq 0 ]; then
+        tags=(StudyInstanceUID SeriesInstanceUID SOPInstanceUID)
+    fi
+
+    local pattern
+    pattern="$(IFS='|'; printf '%s' "${tags[*]}")"
+
+    local count
+    count=$(printf '%s' "${output}" \
+        | tr -d '\0' \
+        | grep -E "${pattern}" \
+        | grep -vc "no value available" \
+        || true)
+
+    # `grep -c` with no matches exits 1; `|| true` suppresses set -e but
+    # leaves count empty. Normalise to 0 so callers can use -eq / -ge.
+    printf '%s' "${count:-0}"
+}
+
 # ── Verify SCP reachability via C-ECHO ────────────────
 # Usage: ensure_scp_reachable "label" "host" "port" "called_ae" "calling_ae"
 # Returns 0 if reachable, 1 otherwise. Prints a one-line preamble status.
@@ -173,12 +219,14 @@ ensure_pacs_data() {
         fi
     fi
 
-    # Check if PACS already has data
+    # Check if PACS already has data. Strip NUL bytes from the capture so
+    # they do not trigger `ignored null byte` warnings in the test log.
     local check_output existing
-    check_output=$(findscu -aet "${my_ae}" -aec "${pacs_ae}" \
+    check_output=$(findscu -v -aet "${my_ae}" -aec "${pacs_ae}" \
         -S "${pacs_host}" "${pacs_port}" \
-        -k QueryRetrieveLevel=STUDY -k PatientName="*" -k StudyInstanceUID 2>&1 || true)
-    existing=$(echo "${check_output}" | grep -c "StudyInstanceUID" 2>/dev/null || echo "0")
+        -k QueryRetrieveLevel=STUDY -k PatientName="*" -k StudyInstanceUID 2>&1 \
+        | tr -d '\0' || true)
+    existing=$(count_find_responses "${check_output}" StudyInstanceUID)
 
     if [ "${existing}" -lt 3 ]; then
         echo "Loading test data into PACS..."
@@ -220,12 +268,14 @@ ensure_clean_pacs() {
     fi
 
     # Query for any remaining studies; the host-side caller is responsible
-    # for wiping PACS storage before this helper runs.
+    # for wiping PACS storage before this helper runs. Strip NUL bytes from
+    # the capture so they do not trigger `ignored null byte` warnings.
     local check_output remaining
-    check_output=$(findscu -aet "${my_ae}" -aec "${pacs_ae}" \
+    check_output=$(findscu -v -aet "${my_ae}" -aec "${pacs_ae}" \
         -S "${pacs_host}" "${pacs_port}" \
-        -k QueryRetrieveLevel=STUDY -k PatientName="*" -k StudyInstanceUID 2>&1 || true)
-    remaining=$(echo "${check_output}" | grep -c "StudyInstanceUID" 2>/dev/null || echo "0")
+        -k QueryRetrieveLevel=STUDY -k PatientName="*" -k StudyInstanceUID 2>&1 \
+        | tr -d '\0' || true)
+    remaining=$(count_find_responses "${check_output}" StudyInstanceUID)
 
     if [ "${remaining}" -gt 0 ]; then
         echo "ERROR: ensure_clean_pacs: ${remaining} studies remain on ${pacs_ae}@${pacs_host}:${pacs_port}" >&2

--- a/tests/test-store.sh
+++ b/tests/test-store.sh
@@ -90,9 +90,9 @@ FIND_OUTPUT=$(findscu -v -aet "${MY_AE}" -aec "${PACS_AE}" \
     -S "${PACS_HOST}" "${PACS_PORT}" \
     -k QueryRetrieveLevel=STUDY \
     -k PatientName="*" \
-    -k StudyInstanceUID 2>&1 || true)
+    -k StudyInstanceUID 2>&1 | tr -d '\0' || true)
 
-STUDY_COUNT=$(echo "${FIND_OUTPUT}" | grep -c "StudyInstanceUID" 2>/dev/null || echo "0")
+STUDY_COUNT=$(count_find_responses "${FIND_OUTPUT}" StudyInstanceUID)
 if [ "${STUDY_COUNT}" -ge 3 ]; then
     print_pass "C-STORE: verification via C-FIND (found ${STUDY_COUNT} studies, expected >= 3)"
     print_verbose "Stored ${TOTAL_FILES} files across 3 patients"


### PR DESCRIPTION
## What

Stabilizes the `findscu`-based C-FIND counters used in the integration test scripts. A single helper, `count_find_responses`, is introduced in `tests/test-helpers.sh` and every existing `grep -c "StudyInstanceUID"` site is migrated to it.

Affected files:
- `tests/test-helpers.sh` — new helper plus migrated `ensure_pacs_data` and `ensure_clean_pacs`
- `tests/test-find.sh` — `run_find_test` and the nonexistent-patient negative test
- `tests/test-store.sh` — final C-FIND verification step

## Why

Closes #32.

Two issues surfaced while running the test suite:

1. **`integer expression expected`** — the previous `grep -c PATTERN 2>/dev/null || echo "0"` idiom could emit `0\n0` when the source pipeline failed and the `|| echo "0"` fallback ran on top of grep's own `0`. The resulting two-line value crashed `[ "$n" -eq 0 ]` with `integer expression expected`.
2. **`ignored null byte in input`** — `findscu` occasionally emits raw DICOM bytes on stderr, and bash command substitution warned about the embedded NULs every time the output was captured into a variable.

Additionally, verbose `findscu -v` echoes each request key once as `(0020,000d) UI (no value available) ... StudyInstanceUID` *before* the response datasets. Bare `grep -c "StudyInstanceUID"` therefore counted one extra row per request key and could produce a non-zero study count even when zero studies matched.

## How

- New `count_find_responses "<output>" [tags...]` helper:
  - filters out `no value available` lines so only response datasets are counted,
  - strips NUL bytes via `tr -d '\0'` before grep runs,
  - normalises empty matches to `0` so the result is always a single non-negative integer on stdout,
  - defaults to `StudyInstanceUID|SeriesInstanceUID|SOPInstanceUID` when no tag is supplied.
- All four call sites (`test-find.sh:run_find_test`, `test-find.sh` Test 9 negative, `test-store.sh` Test 6 verification, `test-helpers.sh:ensure_pacs_data`, `test-helpers.sh:ensure_clean_pacs`) now use it.
- Every `findscu` capture pipes through `| tr -d '\0'` before assignment, eliminating the bash-side NUL warning.
- The two helpers in `test-helpers.sh` now invoke `findscu -v` so request-echo filtering remains consistent across call sites.

The earlier inline workaround comment in `test-find.sh` ("Verbose findscu echoes the empty request key…") is removed because the same logic is now centralised in `count_find_responses` and documented there.

## Verification

- `bash -n tests/*.sh` — all scripts parse cleanly.
- Helper unit-tested against six simulated cases:
  - empty input → `0`
  - request-key echo only (no responses) → `0`
  - request-key echo + 3 responses → `3`
  - mixed StudyInstanceUID + SeriesInstanceUID across two datasets (default tags) → `4`
  - NUL-byte-contaminated input → `1` with no `null byte` warning leaking to stderr
  - empty input returns a single-character `0` (no `\n0` trailing)
- Capture pipeline simulated with a NUL-emitting fake `findscu`; stderr stayed empty and `[ "$n" -ge 0 ]` evaluated cleanly.

Container-level execution is left to the leader's follow-up verification, as required by the issue's "Docker 환경이 없으면 syntax check만" guidance.

## Notes

- Helper name `count_find_responses` was chosen to avoid colliding with the receiver-cleanup helper introduced in #33.
- `findscu -X` (XML output) was considered per the issue scope but skipped: the response-boundary grep approach is simpler, works on the current Debian DCMTK package without further verification, and required less surface area than the XML option.

Closes #32
