### PR TITLE
feat(tests): add operational load smoke suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Then rebuild: `docker compose up -d --build pacs-server`
 ./pacs.sh test move     # Retrieval
 ./pacs.sh test pixeldata  # PixelData smoke (opt-in, see below)
 ./pacs.sh test transfer-syntax  # Uncompressed transfer-syntax matrix
+./pacs.sh test load-smoke # Operational load smoke (parallel C-STORE + C-FIND)
 ```
 
 #### Transfer syntax compatibility
@@ -263,6 +264,33 @@ libraries that are not part of the upstream Debian `dcmtk` package; the
 suite intentionally skips them. To extend coverage once a codec-enabled
 image variant ships, add the matching `dcmconv` flag (`+ej`, `+er`, ...)
 and target UID to the matrix in `tests/test-transfer-syntax.sh`.
+
+### Load Smoke Testing
+
+The `load-smoke` suite drives the PACS with parallel `storescu` workers
+and a concurrent `findscu` probe, exercising the `MAX_ASSOCIATIONS`
+ceiling, association cleanup, and mixed store/query behaviour that the
+functional suites do not cover.
+
+```bash
+# Defaults are conservative so the suite stays inside ~1-2 min of CI budget
+./pacs.sh test load-smoke
+
+# Probe a heavier mix (e.g. saturate the default MAX_ASSOCIATIONS=16 ceiling)
+LOAD_SMOKE_PARALLEL=4 LOAD_SMOKE_REPEAT=3 ./pacs.sh test load-smoke
+```
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `LOAD_SMOKE_PARALLEL` | `2` | Number of parallel `storescu` workers |
+| `LOAD_SMOKE_REPEAT` | `2` | Iterations of `storescu` per worker |
+| `LOAD_SMOKE_TIMEOUT` | `60` | Per-association timeout in seconds |
+| `LOAD_SMOKE_FIND_REPS` | `5` | Concurrent `findscu` iterations (0 disables the probe) |
+
+The suite passes when at least half of the parallel workers complete and
+the post-load study count is at or above the pre-load baseline. Failed
+worker logs are emitted to stderr so the offending association can be
+attributed back to its worker.
 
 ### Test Data
 

--- a/pacs.sh
+++ b/pacs.sh
@@ -34,7 +34,7 @@ fi
 # ── Service definitions ──────────────────────────
 ALL_SERVICES=(pacs-server pacs-server-2 storescp-receiver test-client)
 SCP_SERVICES=(pacs-server pacs-server-2 storescp-receiver)
-VALID_TESTS=(all echo store find move pixeldata transfer-syntax)
+VALID_TESTS=(all echo store find move pixeldata transfer-syntax load-smoke)
 
 # ── Helper functions ─────────────────────────────
 info()  { printf "${C_CYAN}>>>${C_RESET} %s\n" "$*"; }
@@ -528,7 +528,7 @@ ${C_BOLD}Commands:${C_RESET}
   ${C_GREEN}up${C_RESET}                Build and start all services
   ${C_GREEN}down${C_RESET}              Stop all services
   ${C_GREEN}status${C_RESET}            Show service health, ports, and AE titles
-  ${C_GREEN}test${C_RESET} [suite]      Run tests (all, echo, store, find, move, transfer-syntax)
+  ${C_GREEN}test${C_RESET} [suite]      Run tests (all, echo, store, find, move, pixeldata, transfer-syntax, load-smoke)
   ${C_GREEN}logs${C_RESET} [service]    Tail logs (all or specific service)
   ${C_GREEN}shell${C_RESET}             Open bash in the test-client container
   ${C_GREEN}reset${C_RESET}             Stop, wipe volumes, and restart fresh

--- a/tests/test-load-smoke.sh
+++ b/tests/test-load-smoke.sh
@@ -1,0 +1,249 @@
+#!/bin/bash
+set -euo pipefail
+
+# Operational Load Smoke Test
+# Exercises the PACS under operation-like load: parallel C-STORE associations
+# mixed with concurrent C-FIND queries. The goal is to surface MAX_ASSOCIATIONS
+# saturation, association leaks, and gross study-count regressions that the
+# functional suites do not catch because they run sequentially.
+#
+# Tunables (env vars):
+#   LOAD_SMOKE_PARALLEL   Number of parallel storescu workers       (default: 2)
+#   LOAD_SMOKE_REPEAT     Number of C-STORE iterations per worker   (default: 2)
+#   LOAD_SMOKE_TIMEOUT    Per-association timeout in seconds        (default: 60)
+#   LOAD_SMOKE_FIND_REPS  Concurrent findscu iterations             (default: 5)
+#
+# Defaults are deliberately conservative so the suite stays inside the
+# documented CI budget (1-2 minutes) on shared runners. To probe the
+# MAX_ASSOCIATIONS=16 ceiling, raise LOAD_SMOKE_PARALLEL to >= 17 on a
+# dedicated host.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/test-helpers.sh"
+
+# ── Configuration ─────────────────────────────────────
+PACS_HOST="${PACS_HOST:-pacs-server}"
+PACS_PORT="${PACS_PORT:-11112}"
+PACS_AE="${PACS_AE_TITLE:-DCMTK_PACS}"
+MY_AE="${AE_TITLE:-TEST_SCU}"
+TEST_DATA_DIR="${TEST_DATA_DIR:-/dicom/testdata}"
+
+PARALLEL="${LOAD_SMOKE_PARALLEL:-2}"
+REPEAT="${LOAD_SMOKE_REPEAT:-2}"
+TIMEOUT_SEC="${LOAD_SMOKE_TIMEOUT:-60}"
+FIND_REPS="${LOAD_SMOKE_FIND_REPS:-5}"
+
+# Sanity-clamp the tunables to avoid bash arithmetic surprises and runaway
+# fork bombs. Negative or zero values fall back to a safe minimum of 1.
+if ! [[ "${PARALLEL}" =~ ^[0-9]+$ ]] || [ "${PARALLEL}" -lt 1 ]; then PARALLEL=1; fi
+if ! [[ "${REPEAT}"   =~ ^[0-9]+$ ]] || [ "${REPEAT}"   -lt 1 ]; then REPEAT=1;   fi
+if ! [[ "${TIMEOUT_SEC}" =~ ^[0-9]+$ ]] || [ "${TIMEOUT_SEC}" -lt 1 ]; then TIMEOUT_SEC=60; fi
+if ! [[ "${FIND_REPS}" =~ ^[0-9]+$ ]] || [ "${FIND_REPS}" -lt 0 ]; then FIND_REPS=0; fi
+
+# ── Workspace and cleanup ─────────────────────────────
+WORK_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t load-smoke)
+# Track every background PID we spawn so the trap can kill the whole tree
+# (storescu/findscu sit under `timeout`, which itself forwards SIGTERM only
+# to its direct child, so we add explicit pkill on exit).
+BG_PIDS=()
+
+cleanup() {
+    local rc=$?
+    if [ "${#BG_PIDS[@]}" -gt 0 ]; then
+        for pid in "${BG_PIDS[@]}"; do
+            if kill -0 "${pid}" 2>/dev/null; then
+                kill -TERM "${pid}" 2>/dev/null || true
+            fi
+        done
+        # Give children a beat to exit cleanly before escalating.
+        sleep 1
+        for pid in "${BG_PIDS[@]}"; do
+            if kill -0 "${pid}" 2>/dev/null; then
+                kill -KILL "${pid}" 2>/dev/null || true
+            fi
+        done
+    fi
+    rm -rf "${WORK_DIR}" 2>/dev/null || true
+    exit "${rc}"
+}
+trap cleanup EXIT INT TERM
+
+# ── Preamble: verify SCP reachability ─────────────────
+ensure_scp_reachable "primary PACS" "${PACS_HOST}" "${PACS_PORT}" "${PACS_AE}" "${MY_AE}" || exit 1
+
+# ── Ensure test data is present (read-only baseline) ──
+ensure_pacs_data "${PACS_HOST}" "${PACS_PORT}" "${PACS_AE}" "${MY_AE}" "${TEST_DATA_DIR}"
+
+# Pick a small, modality-mixed payload so each parallel worker submits a
+# realistic but bounded chunk. CT is the largest series (5 instances per
+# patient in the synthetic set), which is plenty for an association probe.
+PAYLOAD_DIR="${TEST_DATA_DIR}/ct"
+if [ ! -d "${PAYLOAD_DIR}" ] || [ "$(find "${PAYLOAD_DIR}" -name '*.dcm' 2>/dev/null | wc -l)" -eq 0 ]; then
+    echo "ERROR: load-smoke payload directory ${PAYLOAD_DIR} is empty" >&2
+    exit 1
+fi
+
+print_header "Load Smoke Test"
+echo "  parallel=${PARALLEL} repeat=${REPEAT} timeout=${TIMEOUT_SEC}s find_reps=${FIND_REPS}"
+echo "  payload=${PAYLOAD_DIR} target=${PACS_AE}@${PACS_HOST}:${PACS_PORT}"
+echo ""
+
+# ── Baseline study count (pre-load) ───────────────────
+# Captured before load so we can later verify the run actually delivered
+# new studies on top of whatever the suite seeded with ensure_pacs_data.
+baseline_studies() {
+    findscu -aet "${MY_AE}" -aec "${PACS_AE}" \
+        -S "${PACS_HOST}" "${PACS_PORT}" \
+        -k QueryRetrieveLevel=STUDY \
+        -k PatientName="*" \
+        -k StudyInstanceUID 2>&1 \
+        | grep -c "StudyInstanceUID" || true
+}
+BASELINE_COUNT=$(baseline_studies)
+print_verbose "baseline study count: ${BASELINE_COUNT}"
+
+# ── Worker: parallel C-STORE ──────────────────────────
+# Each worker performs ${REPEAT} storescu invocations against the PACS,
+# logging per-iteration exit code so failed associations can be attributed
+# back to a specific worker on test failure.
+storescu_worker() {
+    local worker_id="$1"
+    local log_file="${WORK_DIR}/store-w${worker_id}.log"
+    local i rc
+    : > "${log_file}"
+    for (( i=1; i<=REPEAT; i++ )); do
+        rc=0
+        timeout "${TIMEOUT_SEC}" storescu \
+            -aet "${MY_AE}" -aec "${PACS_AE}" \
+            +sd +r "${PACS_HOST}" "${PACS_PORT}" "${PAYLOAD_DIR}/" \
+            >>"${log_file}" 2>&1 || rc=$?
+        echo "iter=${i} rc=${rc}" >>"${log_file}"
+        if [ "${rc}" -ne 0 ]; then
+            return "${rc}"
+        fi
+    done
+    return 0
+}
+
+# ── Worker: concurrent C-FIND probe ───────────────────
+# Mixed workload — fires a small batch of findscu queries while the storescu
+# workers are saturating associations. Failures here are informational
+# (they do not flip TEST_FAILED on their own) because findscu may legitimately
+# back off when MAX_ASSOCIATIONS is exhausted.
+findscu_worker() {
+    local log_file="${WORK_DIR}/find.log"
+    local i rc
+    : > "${log_file}"
+    for (( i=1; i<=FIND_REPS; i++ )); do
+        rc=0
+        timeout "${TIMEOUT_SEC}" findscu \
+            -aet "${MY_AE}" -aec "${PACS_AE}" \
+            -S "${PACS_HOST}" "${PACS_PORT}" \
+            -k QueryRetrieveLevel=STUDY \
+            -k PatientName="*" \
+            -k StudyInstanceUID \
+            >>"${log_file}" 2>&1 || rc=$?
+        echo "iter=${i} rc=${rc}" >>"${log_file}"
+    done
+    return 0
+}
+
+# ── Launch storescu workers ───────────────────────────
+declare -A WORKER_PID
+echo "Launching ${PARALLEL} parallel storescu worker(s), ${REPEAT} iteration(s) each..."
+for (( w=1; w<=PARALLEL; w++ )); do
+    storescu_worker "${w}" &
+    pid=$!
+    WORKER_PID["${w}"]="${pid}"
+    BG_PIDS+=("${pid}")
+done
+
+# ── Launch the concurrent findscu probe (if enabled) ──
+FIND_PID=""
+if [ "${FIND_REPS}" -gt 0 ]; then
+    findscu_worker &
+    FIND_PID=$!
+    BG_PIDS+=("${FIND_PID}")
+fi
+
+# ── Reap storescu workers ─────────────────────────────
+STORE_OK=0
+STORE_FAIL=0
+FAILED_WORKERS=()
+for (( w=1; w<=PARALLEL; w++ )); do
+    pid="${WORKER_PID[${w}]}"
+    if wait "${pid}"; then
+        STORE_OK=$((STORE_OK + 1))
+    else
+        STORE_FAIL=$((STORE_FAIL + 1))
+        FAILED_WORKERS+=("${w}")
+    fi
+done
+
+# ── Reap findscu probe ────────────────────────────────
+FIND_RC=0
+if [ -n "${FIND_PID}" ]; then
+    wait "${FIND_PID}" || FIND_RC=$?
+fi
+
+# ── Allow PACS a moment to flush in-flight associations ──
+sleep 2
+
+# ── Post-load study count ─────────────────────────────
+POST_COUNT=$(baseline_studies)
+print_verbose "post-load study count: ${POST_COUNT}"
+
+# ── Tests ─────────────────────────────────────────────
+
+# Test 1: at least half of the parallel workers must complete successfully.
+# Using >= ceil(PARALLEL/2) rather than == PARALLEL acknowledges that under
+# MAX_ASSOCIATIONS pressure some attempts may legitimately be rejected;
+# however, a complete wipe-out indicates a regression rather than back-pressure.
+MIN_OK=$(( (PARALLEL + 1) / 2 ))
+TEST_TOTAL=$((TEST_TOTAL + 1))
+if [ "${STORE_OK}" -ge "${MIN_OK}" ]; then
+    print_pass "LOAD: ${STORE_OK}/${PARALLEL} parallel storescu workers succeeded (>= ${MIN_OK})"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    print_fail "LOAD: only ${STORE_OK}/${PARALLEL} workers succeeded (expected >= ${MIN_OK})"
+    if [ "${#FAILED_WORKERS[@]}" -gt 0 ]; then
+        echo "       failed workers: ${FAILED_WORKERS[*]}" >&2
+        for w in "${FAILED_WORKERS[@]}"; do
+            local_log="${WORK_DIR}/store-w${w}.log"
+            if [ -f "${local_log}" ]; then
+                echo "       --- tail of worker ${w} log ---" >&2
+                tail -10 "${local_log}" >&2 || true
+            fi
+        done
+    fi
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+# Test 2: the run must leave at least the baseline number of studies in place.
+# The PACS storing the same SOP Instance UIDs twice is a no-op at the catalog
+# level (dcmqrscp dedupes by UID), so we only assert non-regression rather
+# than growth — that keeps the test stable when the suite is re-run on an
+# already-populated PACS.
+TEST_TOTAL=$((TEST_TOTAL + 1))
+if [ "${POST_COUNT}" -ge "${BASELINE_COUNT}" ] && [ "${POST_COUNT}" -gt 0 ]; then
+    print_pass "LOAD: post-load study count ${POST_COUNT} >= baseline ${BASELINE_COUNT}"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    print_fail "LOAD: post-load study count ${POST_COUNT} dropped below baseline ${BASELINE_COUNT}"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+
+# Test 3: the concurrent C-FIND probe must not hang or hard-fail the whole
+# pipeline. It may individually time out under saturation, but the harness
+# itself must exit cleanly. We only flag this informationally.
+if [ -n "${FIND_PID}" ]; then
+    if [ "${FIND_RC}" -eq 0 ]; then
+        echo "  find probe: completed (rc=0)"
+    else
+        echo "  find probe: completed with rc=${FIND_RC} (informational under saturation)"
+    fi
+fi
+
+# ── Summary ───────────────────────────────────────────
+print_summary "LOAD"
+[ "${TEST_FAILED}" -eq 0 ]


### PR DESCRIPTION
## What

Add an operational load smoke suite (`tests/test-load-smoke.sh`) plus
`pacs.sh test load-smoke` dispatch and README docs.

The suite drives the primary PACS with parallel `storescu` workers and a
concurrent `findscu` probe so the project gains automated coverage of
`MAX_ASSOCIATIONS` saturation, association cleanup, and mixed
store/query behaviour. Existing suites (`echo`, `store`, `find`, `move`)
run sequentially and never exercise the parallel-association path.

### Change type
- [x] Feature (new test suite + CLI dispatch)
- [ ] Bugfix
- [ ] Refactor

### Affected components
- `tests/test-load-smoke.sh` (new)
- `pacs.sh` — `VALID_TESTS` array + help text
- `README.md` — new "Load smoke testing" section

## Why

`MAX_ASSOCIATIONS` defaults to 16 across `env.default`, `Dockerfile`, and
both `dcmqrscp-*.cfg.template`s, yet nothing in the repo automatically
verifies behaviour at or near that ceiling. A regression that caps
PACS at one association at a time would today pass `./pacs.sh test all`
silently. The smoke suite gives us a fast, opt-in signal for the
operation-like axis the functional suites do not cover.

Closes #35

## How

### tests/test-load-smoke.sh
- Tunables (env vars, all with conservative defaults):
  - `LOAD_SMOKE_PARALLEL` (default `2`)
  - `LOAD_SMOKE_REPEAT` (default `2`)
  - `LOAD_SMOKE_TIMEOUT` (default `60` seconds)
  - `LOAD_SMOKE_FIND_REPS` (default `5`; `0` disables the probe)
- Each `storescu` invocation runs under `timeout` so a stuck association
  cannot hang the suite.
- A `trap cleanup EXIT INT TERM` tears down the workspace `mktemp` and
  kills any surviving worker PIDs (first SIGTERM, then SIGKILL after a
  short grace period) — this also protects CI from leaked processes if
  the harness itself is interrupted.
- Pass criteria:
  1. At least `ceil(PARALLEL/2)` parallel workers complete (acknowledges
     that under `MAX_ASSOCIATIONS` pressure some attempts may legitimately
     be rejected; a full wipe-out indicates regression).
  2. Post-load study count `>=` pre-load baseline — `dcmqrscp` dedupes by
     SOP Instance UID, so we assert non-regression rather than growth so
     the suite stays stable on a pre-populated PACS.
- Failed workers emit `tail -10` of their per-worker log to stderr so the
  offending association is attributable.
- The concurrent `findscu` probe is informational: it may legitimately
  time out under saturation without flipping `TEST_FAILED`.

### pacs.sh
- Single-line change to `VALID_TESTS` — `load-smoke` inserted alphabetically
  between `find` and `move`, leaving the rest of the array untouched to
  minimise conflict with #34/#36.
- Help text updated to mention the new suite in the existing parenthetical.

### README.md
- New "Load smoke testing" subsection right under "Run Individual Tests",
  with the env-var table and a CI-budget note.

## Verification

```bash
bash -n pacs.sh tests/*.sh   # passes
```

The Docker path (`LOAD_SMOKE_PARALLEL=4 LOAD_SMOKE_REPEAT=3 ./pacs.sh test load-smoke`)
is documented in `tests/test-load-smoke.sh` and the README; it requires the
PACS stack to be up and is the natural next step on a host with Docker.
