### PR TITLE
fix(tests): verify c-move arrivals on receiver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,9 +128,15 @@ services:
       - CR_PIXEL_COLS=${CR_PIXEL_COLS:-}
       - TEST_DATA_DIR=/dicom/testdata
       - OID_ROOT=${OID_ROOT:-1.2.826.0.1.3680043.8.499}
+      - STORESCP_STORAGE_DIR=/dicom/received
     volumes:
       - ./data:/dicom/testdata
       - ./tests:/tests:ro
+      # Mount the storescp-receiver storage so C-MOVE tests can clean
+      # incoming files between cases and verify the arrived instances
+      # (count + DICOM UID match) instead of relying on movescu exit
+      # codes alone. See issue #33.
+      - received-data:/dicom/received
     networks:
       - dicom-net
     depends_on:

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -236,3 +236,170 @@ ensure_clean_pacs() {
     echo "  ensure_clean_pacs: ${pacs_ae}@${pacs_host}:${pacs_port} is empty"
     return 0
 }
+
+# ── C-MOVE receiver verification helpers ──────────────────────
+# These helpers let C-MOVE tests verify that the requested instances
+# actually arrived at the storescp-receiver destination, instead of
+# trusting movescu's exit code alone. They depend on the receiver
+# storage volume (`received-data`) being mounted into test-client at
+# ${STORESCP_STORAGE_DIR} (default /dicom/received); see issue #33.
+#
+# Layout: storescp runs with `--sort-on-study-uid prefix`, which
+# produces `<prefix><StudyInstanceUID>/<file>.dcm` under the storage
+# directory. The helpers below use `find` + DICOM tags from dcmdump
+# rather than assuming a specific directory layout, so they stay
+# robust if the sorting strategy changes.
+
+# Resolve the receiver storage directory (env override → default).
+receiver_storage_dir() {
+    echo "${STORESCP_STORAGE_DIR:-/dicom/received}"
+}
+
+# Remove every previously-received instance under the receiver storage
+# directory. Non-destructive on the directory itself so storescp can
+# keep writing new files into it without restarting.
+#
+# Usage: receiver_cleanup_storage [storage_dir]
+receiver_cleanup_storage() {
+    local storage_dir="${1:-$(receiver_storage_dir)}"
+
+    if [ ! -d "${storage_dir}" ]; then
+        echo "ERROR: receiver_cleanup_storage: ${storage_dir} not mounted in test-client" >&2
+        echo "       Ensure docker-compose.yml mounts received-data into test-client." >&2
+        return 1
+    fi
+
+    # Delete every regular file and empty sub-directory below storage_dir,
+    # but keep storage_dir itself so storescp can continue writing.
+    find "${storage_dir}" -mindepth 1 -delete 2>/dev/null || true
+    print_verbose "receiver_cleanup_storage: wiped ${storage_dir}"
+    return 0
+}
+
+# Count .dcm files under the receiver storage directory.
+#
+# Usage: receiver_dcm_count [storage_dir]
+# Prints the file count on stdout.
+receiver_dcm_count() {
+    local storage_dir="${1:-$(receiver_storage_dir)}"
+
+    if [ ! -d "${storage_dir}" ]; then
+        echo "0"
+        return 1
+    fi
+
+    find "${storage_dir}" -type f -name '*.dcm' 2>/dev/null | wc -l | tr -d ' '
+}
+
+# Dump receiver storage contents on failure to aid debugging.
+#
+# Usage: receiver_dump_storage [storage_dir]
+receiver_dump_storage() {
+    local storage_dir="${1:-$(receiver_storage_dir)}"
+
+    echo "       Receiver storage (${storage_dir}):"
+    if [ -d "${storage_dir}" ]; then
+        find "${storage_dir}" -type f -name '*.dcm' 2>/dev/null \
+            | head -20 \
+            | sed 's/^/         /' \
+            || true
+    else
+        echo "         (not mounted)"
+    fi
+}
+
+# Verify that exactly `expected` .dcm files exist under the receiver
+# storage directory. Increments TEST_TOTAL and TEST_PASSED/FAILED so
+# the C-MOVE suite picks up the result via print_summary.
+#
+# Usage: verify_move_count "<test label>" <expected> [storage_dir]
+verify_move_count() {
+    local label="$1"
+    local expected="$2"
+    local storage_dir="${3:-$(receiver_storage_dir)}"
+
+    TEST_TOTAL=$((TEST_TOTAL + 1))
+    local actual
+    actual=$(receiver_dcm_count "${storage_dir}")
+
+    if [ "${actual}" = "${expected}" ]; then
+        print_pass "C-MOVE: ${label} (received ${actual}/${expected} instances)"
+        TEST_PASSED=$((TEST_PASSED + 1))
+        return 0
+    fi
+
+    print_fail "C-MOVE: ${label} (received ${actual} instances, expected ${expected})"
+    receiver_dump_storage "${storage_dir}"
+    TEST_FAILED=$((TEST_FAILED + 1))
+    return 1
+}
+
+# Verify that every .dcm file under the receiver storage directory
+# carries the expected StudyInstanceUID and, when provided, the
+# expected SeriesInstanceUID. Uses dcmdump's +P selector to read
+# specific tags without parsing the full dataset.
+#
+# Usage: verify_move_uids "<test label>" <study_uid> [series_uid] [storage_dir]
+verify_move_uids() {
+    local label="$1"
+    local study_uid="$2"
+    local series_uid="${3:-}"
+    local storage_dir="${4:-$(receiver_storage_dir)}"
+
+    TEST_TOTAL=$((TEST_TOTAL + 1))
+
+    if ! command -v dcmdump >/dev/null 2>&1; then
+        print_fail "C-MOVE: ${label} (dcmdump not available)"
+        TEST_FAILED=$((TEST_FAILED + 1))
+        return 1
+    fi
+
+    local files file extracted mismatched_study=0 mismatched_series=0 missing_sop=0 scanned=0
+    files=$(find "${storage_dir}" -type f -name '*.dcm' 2>/dev/null)
+
+    if [ -z "${files}" ]; then
+        print_fail "C-MOVE: ${label} (no instances to inspect under ${storage_dir})"
+        TEST_FAILED=$((TEST_FAILED + 1))
+        return 1
+    fi
+
+    while IFS= read -r file; do
+        [ -z "${file}" ] && continue
+        scanned=$((scanned + 1))
+
+        extracted=$(dcmdump +P StudyInstanceUID "${file}" 2>/dev/null \
+            | sed -n 's/.*\[\([^]]*\)\].*/\1/p' | head -1)
+        if [ "${extracted}" != "${study_uid}" ]; then
+            mismatched_study=$((mismatched_study + 1))
+            print_verbose "verify_move_uids: study mismatch in ${file} (got '${extracted}', expected '${study_uid}')"
+        fi
+
+        if [ -n "${series_uid}" ]; then
+            extracted=$(dcmdump +P SeriesInstanceUID "${file}" 2>/dev/null \
+                | sed -n 's/.*\[\([^]]*\)\].*/\1/p' | head -1)
+            if [ "${extracted}" != "${series_uid}" ]; then
+                mismatched_series=$((mismatched_series + 1))
+                print_verbose "verify_move_uids: series mismatch in ${file} (got '${extracted}', expected '${series_uid}')"
+            fi
+        fi
+
+        extracted=$(dcmdump +P SOPInstanceUID "${file}" 2>/dev/null \
+            | sed -n 's/.*\[\([^]]*\)\].*/\1/p' | head -1)
+        if [ -z "${extracted}" ]; then
+            missing_sop=$((missing_sop + 1))
+        fi
+    done <<EOF
+${files}
+EOF
+
+    if [ "${mismatched_study}" -eq 0 ] && [ "${mismatched_series}" -eq 0 ] && [ "${missing_sop}" -eq 0 ]; then
+        print_pass "C-MOVE: ${label} (${scanned} instances match expected UIDs)"
+        TEST_PASSED=$((TEST_PASSED + 1))
+        return 0
+    fi
+
+    print_fail "C-MOVE: ${label} (scanned=${scanned} study-mismatch=${mismatched_study} series-mismatch=${mismatched_series} missing-sop=${missing_sop})"
+    receiver_dump_storage "${storage_dir}"
+    TEST_FAILED=$((TEST_FAILED + 1))
+    return 1
+}

--- a/tests/test-move.sh
+++ b/tests/test-move.sh
@@ -21,7 +21,13 @@ STORESCP_HOST="${STORESCP_HOST:-storescp-receiver}"
 STORESCP_AE="${STORESCP_AE_TITLE:-STORE_SCP}"
 TEST_DATA_DIR="${TEST_DATA_DIR:-/dicom/testdata}"
 OID_ROOT="${OID_ROOT:-${DEFAULT_OID_ROOT}}"
+RECEIVER_STORAGE_DIR="$(receiver_storage_dir)"
+# Settle window for storescp to flush incoming instances to disk before
+# we count them. Keep small to avoid inflating wall-clock time when the
+# whole suite runs.
+MOVE_SETTLE_SECONDS="${MOVE_SETTLE_SECONDS:-2}"
 print_verbose "OID_ROOT=${OID_ROOT}"
+print_verbose "RECEIVER_STORAGE_DIR=${RECEIVER_STORAGE_DIR}"
 
 # ── Preamble: verify required SCPs are reachable ──────
 # Both the source PACS and the storescp-receiver destination must be up
@@ -48,34 +54,55 @@ else
     exit 1
 fi
 
+# ── Receiver storage cleanup (precondition) ───────────
+# Wipe any instances left behind by a previous suite run so the per-case
+# count and UID checks below reflect what THIS test actually retrieved.
+# See issue #33.
+receiver_cleanup_storage "${RECEIVER_STORAGE_DIR}" || exit 1
+
 # ── Test 1: C-MOVE CT study (PAT001, 5 instances) ────
 CT_STUDY_UID="${OID_ROOT}.1.1"
+CT_EXPECTED=5
+receiver_cleanup_storage "${RECEIVER_STORAGE_DIR}"
 run_test "retrieve CT study PAT001 to ${STORESCP_AE}" "C-MOVE" \
     movescu -aet "${MY_AE}" -aec "${PACS_AE}" -aem "${STORESCP_AE}" \
         -S "${PACS_HOST}" "${PACS_PORT}" \
         -k QueryRetrieveLevel=STUDY \
         -k StudyInstanceUID="${CT_STUDY_UID}" || true
-sleep 2
+sleep "${MOVE_SETTLE_SECONDS}"
+verify_move_count "CT study PAT001 instance count" "${CT_EXPECTED}" "${RECEIVER_STORAGE_DIR}" || true
+verify_move_uids  "CT study PAT001 UIDs"           "${CT_STUDY_UID}" "" "${RECEIVER_STORAGE_DIR}" || true
 
 # ── Test 2: C-MOVE MR study (PAT002, 6 instances) ────
 MR_STUDY_UID="${OID_ROOT}.2.1"
+MR_EXPECTED=6
+receiver_cleanup_storage "${RECEIVER_STORAGE_DIR}"
 run_test "retrieve MR study PAT002 to ${STORESCP_AE}" "C-MOVE" \
     movescu -aet "${MY_AE}" -aec "${PACS_AE}" -aem "${STORESCP_AE}" \
         -S "${PACS_HOST}" "${PACS_PORT}" \
         -k QueryRetrieveLevel=STUDY \
         -k StudyInstanceUID="${MR_STUDY_UID}" || true
-sleep 2
+sleep "${MOVE_SETTLE_SECONDS}"
+verify_move_count "MR study PAT002 instance count" "${MR_EXPECTED}" "${RECEIVER_STORAGE_DIR}" || true
+verify_move_uids  "MR study PAT002 UIDs"           "${MR_STUDY_UID}" "" "${RECEIVER_STORAGE_DIR}" || true
 
 # ── Test 3: C-MOVE CR study (PAT003, 2 instances) ────
 CR_STUDY_UID="${OID_ROOT}.3.1"
+CR_EXPECTED=2
+receiver_cleanup_storage "${RECEIVER_STORAGE_DIR}"
 run_test "retrieve CR study PAT003 to ${STORESCP_AE}" "C-MOVE" \
     movescu -aet "${MY_AE}" -aec "${PACS_AE}" -aem "${STORESCP_AE}" \
         -S "${PACS_HOST}" "${PACS_PORT}" \
         -k QueryRetrieveLevel=STUDY \
         -k StudyInstanceUID="${CR_STUDY_UID}" || true
-sleep 2
+sleep "${MOVE_SETTLE_SECONDS}"
+verify_move_count "CR study PAT003 instance count" "${CR_EXPECTED}" "${RECEIVER_STORAGE_DIR}" || true
+verify_move_uids  "CR study PAT003 UIDs"           "${CR_STUDY_UID}" "" "${RECEIVER_STORAGE_DIR}" || true
 
 # ── Test 4: C-MOVE nonexistent study (graceful) ──────
+# Nonexistent retrievals must not leave anything on the receiver. Clean
+# first so the count check below isolates this case.
+receiver_cleanup_storage "${RECEIVER_STORAGE_DIR}"
 TEST_TOTAL=$((TEST_TOTAL + 1))
 MOVE_OUTPUT=$(movescu -v -aet "${MY_AE}" -aec "${PACS_AE}" -aem "${STORESCP_AE}" \
     -S "${PACS_HOST}" "${PACS_PORT}" \
@@ -89,17 +116,23 @@ else
     print_pass "C-MOVE: nonexistent study handled gracefully"
     TEST_PASSED=$((TEST_PASSED + 1))
 fi
+sleep "${MOVE_SETTLE_SECONDS}"
+verify_move_count "nonexistent study leaves receiver empty" 0 "${RECEIVER_STORAGE_DIR}" || true
 
 # ── Test 5: C-MOVE at SERIES level ───────────────────
-# Retrieve only the T1 series from PAT002's MR study
+# Retrieve only the T1 series from PAT002's MR study (3 instances).
 T1_SERIES_UID="${OID_ROOT}.2.1.1"
+T1_EXPECTED=3
+receiver_cleanup_storage "${RECEIVER_STORAGE_DIR}"
 run_test "retrieve MR T1 series (SERIES level) to ${STORESCP_AE}" "C-MOVE" \
     movescu -aet "${MY_AE}" -aec "${PACS_AE}" -aem "${STORESCP_AE}" \
         -S "${PACS_HOST}" "${PACS_PORT}" \
         -k QueryRetrieveLevel=SERIES \
         -k StudyInstanceUID="${MR_STUDY_UID}" \
         -k SeriesInstanceUID="${T1_SERIES_UID}" || true
-sleep 1
+sleep "${MOVE_SETTLE_SECONDS}"
+verify_move_count "MR T1 series instance count"  "${T1_EXPECTED}"     "${RECEIVER_STORAGE_DIR}" || true
+verify_move_uids  "MR T1 series UIDs"            "${MR_STUDY_UID}"    "${T1_SERIES_UID}" "${RECEIVER_STORAGE_DIR}" || true
 
 # ── Test 6: Receiver health after transfers ───────────
 TEST_TOTAL=$((TEST_TOTAL + 1))


### PR DESCRIPTION
## What

Promote the C-MOVE test from a smoke check (movescu exit code + receiver
liveness) to an arrival check: clean the receiver storage between cases,
count the `.dcm` files that landed, and confirm each instance carries
the StudyInstanceUID (and SeriesInstanceUID, when applicable) that the
test requested.

## Why

`tests/test-move.sh` previously reported PASS whenever `movescu` returned
exit 0 and `storescp-receiver` answered C-ECHO afterwards. That left two
silent failure modes uncovered:

1. The PACS could short-circuit the transfer and the receiver could still
   look healthy.
2. A misrouted C-STORE could land files for a different study without the
   test ever noticing.

Both are exactly the regressions the C-MOVE suite is supposed to catch.

Closes #33

## Where

- `docker-compose.yml`: mount the `received-data` volume into `test-client`
  at `/dicom/received` so the test container can clean and inspect the
  arrived instances directly. The volume already exists for the receiver,
  this just adds a second consumer.
- `tests/test-helpers.sh`: add four new helpers (no edits to the existing
  parser/runner helpers, to avoid colliding with the #32 work in the same
  file):
  - `receiver_storage_dir`
  - `receiver_cleanup_storage`
  - `receiver_dcm_count`
  - `receiver_dump_storage`
  - `verify_move_count`
  - `verify_move_uids`
- `tests/test-move.sh`: clean the receiver before each case, then verify
  the expected instance count and UID match. Nonexistent retrievals are
  asserted to leave the receiver empty.

## How

Each C-MOVE case now follows the pattern:

```
receiver_cleanup_storage  <-- isolate this case
movescu ...               <-- existing retrieval
sleep MOVE_SETTLE_SECONDS <-- let storescp flush to disk
verify_move_count "..."   <-- expected: CT 5, MR 6, CR 2, T1 3, none = 0
verify_move_uids  "..."   <-- StudyInstanceUID (+ SeriesInstanceUID if SERIES level)
```

`verify_move_uids` uses `dcmdump +P` to read specific tags rather than
parsing the full dataset, and ignores the storescp `--sort-on-study-uid`
directory layout in favor of a recursive `find ... -name '*.dcm'` so the
test stays robust against sorting strategy changes (per the issue scope).

On count or UID mismatch, the helper prints a truncated file listing
from the receiver so the failure mode is visible without re-running
under `--verbose`.

`MOVE_SETTLE_SECONDS` (default 2) replaces the hard-coded `sleep 2`/`sleep 1`
calls and is overridable via env for slow CI runners.

## Verification

- `bash -n tests/test-all.sh tests/test-echo.sh tests/test-find.sh
   tests/test-helpers.sh tests/test-move.sh tests/test-pixeldata.sh
   tests/test-store.sh` -> all OK.
- `docker compose config` was not run in this worktree because no Docker
  daemon is available locally; the YAML parses cleanly and the new mount
  is a single `received-data:/dicom/received` line under `test-client`.
- Expected counts (`CT 5`, `MR 6`, `CR 2`, `T1 series 3`) cross-checked
  against `scripts/generate-test-data.sh` (`OID_ROOT.{1,2,3}.x`).

## Notes

- Helpers are additive only; existing `ensure_clean_pacs`,
  `ensure_scp_reachable`, `ensure_pacs_data`, `run_test`, and
  `run_test_expect_fail` are untouched to avoid merge conflicts with #32.
- The receiver storage volume mount intentionally lives only on
  `test-client`, not on `pacs.sh`; cleanup runs inside the test container
  rather than via host-side Docker exec (which is the pattern the PACS
  side uses for issue #19, but is not needed here because the receiver
  volume is a separate Docker volume from the PACS volumes).
