### PR TITLE
fix(tests): restore c-move receiver verification on isolated runs

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -116,6 +116,7 @@ start_storescp() {
         --output-directory "${STORAGE_DIR}" \
         --aetitle "${AE_TITLE}" \
         --sort-on-study-uid prefix \
+        --filename-extension .dcm \
         "${DICOM_PORT}"
 }
 


### PR DESCRIPTION
Closes #46
Part of #45

## What
Restore C-MOVE arrival verification on isolated test runs so the develop branch passes the `Test Isolation` workflow again. PR #43 introduced helpers that searched `/dicom/received` for files matching `*.dcm`, but `storescp` was writing files without any extension (e.g. `CT.1.2.826.0.1.3680043.8.499.1.1.1.1`). The verifier therefore counted zero arrived instances even though storescp logs confirm the C-STORE requests were received and the files were written to disk, causing all four C-MOVE cases (CT/MR/CR/MR T1 series) to fail count + UID checks (8/16 failed).

## Why
develop is currently broken — `test-move.sh (isolated)` and `test-pixeldata.sh with GENERATE_PIXEL_DATA=true` have been failing since #43 was squash-merged. Every push run on develop since `3bd2ed4` has been red. This blocks all follow-up work.

## Where
- `scripts/entrypoint.sh` (the `start_storescp` function only)

## How
Root cause: `storescp` writes received DICOM files without a filename extension by default. The C-MOVE verification helpers added in PR #43 (`receiver_dcm_count`, `verify_move_uids`, `receiver_dump_storage`) all use `find ... -name '*.dcm'`, so they matched zero files regardless of how many instances actually arrived. Failure logs from run `26563133659` confirm storescp emitted `storing DICOM file: /dicom/received/prefix_<study_uid>/CT.<sop_uid>` (no `.dcm` suffix) while `receiver_dcm_count` reported 0.

Fix: pass `--filename-extension .dcm` to `storescp` in the `start_storescp` entrypoint role. This causes every received instance to land with a `.dcm` suffix, restoring the assumption baked into the PR #43 helpers without modifying any test code or the helper implementations.

This is the minimal surgical change — one line added to `scripts/entrypoint.sh` — and it preserves the PR #43 helpers' explicit `*.dcm` matching, which is desirable because it filters out any non-DICOM bookkeeping files that may appear in the storage directory.

## Verification
- All 7 `Test Isolation` checks must pass on this PR.
- Post-merge develop push run must also be green.
