### PR TITLE
feat(tests): fixture manifest as single source of truth (black-box ready)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `VERSION` stamp and this `CHANGELOG.md` so downstream consumers can pin a known release.
 - Conformance / Capabilities table in the README documenting supported vs unsupported DICOM services (DICOMweb, MWL, MPPS, Storage Commitment, TLS, compressed transfer syntaxes).
 - Per-service memory and CPU limits in `docker-compose.yml`.
+- `scripts/fixture-manifest.sh` — a single source of truth for the synthetic fixture identity (OID root, study/series UIDs, instance counts, patient demographics). The data generator and every test script source it, so the suite can be retargeted at an external / non-DCMTK PACS by overriding `OID_ROOT` without editing any assertion. README documents the external-PACS procedure.
 
 ### Changed
 - Network-facing PACS and receiver services now run as a dedicated non-root user (`pacs`, uid 10001) instead of `root`. The test-client helper (no published ports) stays root so it can write synthetic data into the host-bind-mounted `./data`.

--- a/README.md
+++ b/README.md
@@ -346,6 +346,26 @@ wiped safely.
 |------|------|---------|-------|
 | `data/dicom-templates/` | Source fixture | Yes | `*.dump` templates consumed by the generator; never delete |
 | `data/ct/`, `data/mr/`, `data/cr/` | Generated | No | Synthetic DICOM written on first `./pacs.sh up` |
+
+#### Test-data manifest (single source of truth)
+
+The identity of the synthetic dataset — the OID root, every study/series UID,
+the expected instance counts, and the patient demographics — lives in one file:
+`scripts/fixture-manifest.sh`. Both the generator (`scripts/generate-test-data.sh`)
+and the test scripts (via `tests/test-helpers.sh`) source it, so no magic UID or
+count is duplicated where it could drift out of sync.
+
+**Pointing the suite at an external (non-DCMTK) PACS.** Every query key and
+assertion reads from the manifest, so you can validate a third-party archive
+without editing a test:
+
+1. Set `OID_ROOT` to a value that will not collide with the target's data
+   (e.g. `OID_ROOT=1.2.3.myorg.test`).
+2. Generate the dataset (`scripts/generate-test-data.sh`) and load it into the
+   target PACS with `storescu`.
+3. Point the test scripts at the target via the `PACS_HOST` / `PACS_PORT` /
+   `PACS_AE_TITLE` environment variables and run them — the assertions follow
+   `OID_ROOT` automatically.
 | `data/dicom-output/`, `data/received/` | Generated | No | Test runtime artifacts |
 
 To regenerate test data, remove the generated directories and restart:

--- a/scripts/fixture-manifest.sh
+++ b/scripts/fixture-manifest.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# ============================================================================
+# Synthetic test-fixture manifest - SINGLE SOURCE OF TRUTH
+# ============================================================================
+# Defines the identity of the synthetic CT/MR/CR dataset in ONE place so that
+# the producer (scripts/generate-test-data.sh) and the consumers
+# (tests/*.sh, via tests/test-helpers.sh) never drift apart.
+#
+# This file is installed to /usr/local/bin in the image (COPY scripts/), which
+# is the only path reachable from BOTH the PACS/test-client containers and the
+# host. Source it like:
+#   source "$(dirname "$0")/fixture-manifest.sh"      # from scripts/
+#   source /usr/local/bin/fixture-manifest.sh         # from /tests
+#
+# Pointing the suite at a FOREIGN (non-DCMTK) PACS:
+#   1. Set OID_ROOT to a value that will not collide with the target's data.
+#   2. Seed the target PACS with this dataset (storescu the generated files, or
+#      generate-test-data.sh then C-STORE them).
+#   3. Run the test scripts unchanged - every assertion reads the UIDs, counts,
+#      and demographics from this manifest, so they follow OID_ROOT automatically.
+# ============================================================================
+
+# Canonical OID root. An OID_ROOT environment override wins so the whole fixture
+# identity can be relocated; otherwise the project default is used. `:=` sets
+# the variable when unset/empty so downstream consumers see a concrete value.
+: "${OID_ROOT:=1.2.826.0.1.3680043.8.499}"
+
+# Back-compat alias retained for scripts that still reference DEFAULT_OID_ROOT.
+DEFAULT_OID_ROOT="1.2.826.0.1.3680043.8.499"
+
+# Effective OID root used to derive every UID below.
+MANIFEST_OID_ROOT="${OID_ROOT}"
+
+# ── Study / series UIDs (derived from the OID root) ─────────────────────────
+# SOP Instance UIDs are "<series_uid>.<instance_number>", so the test data
+# generator only needs the series UID plus a loop index.
+MANIFEST_CT_STUDY_UID="${MANIFEST_OID_ROOT}.1.1"
+MANIFEST_CT_SERIES_UID="${MANIFEST_OID_ROOT}.1.1.1"
+
+MANIFEST_MR_STUDY_UID="${MANIFEST_OID_ROOT}.2.1"
+MANIFEST_MR_T1_SERIES_UID="${MANIFEST_OID_ROOT}.2.1.1"
+MANIFEST_MR_T2_SERIES_UID="${MANIFEST_OID_ROOT}.2.1.2"
+
+MANIFEST_CR_STUDY_UID="${MANIFEST_OID_ROOT}.3.1"
+MANIFEST_CR_SERIES_UID="${MANIFEST_OID_ROOT}.3.1.1"
+
+# ── Expected counts ─────────────────────────────────────────────────────────
+MANIFEST_CT_COUNT=5
+MANIFEST_MR_T1_COUNT=3
+MANIFEST_MR_T2_COUNT=3
+MANIFEST_MR_COUNT=6          # T1 + T2
+MANIFEST_CR_COUNT=2
+MANIFEST_TOTAL_COUNT=13
+MANIFEST_STUDY_COUNT=3
+MANIFEST_MR_SERIES_COUNT=2   # PAT002 has T1 + T2
+
+# ── Patient 1: CT ───────────────────────────────────────────────────────────
+MANIFEST_CT_PATIENT_NAME="DOE^JOHN"
+MANIFEST_CT_PATIENT_ID="PAT001"
+MANIFEST_CT_PATIENT_SEX="M"
+MANIFEST_CT_STUDY_DATE="20240115"
+MANIFEST_CT_ACCESSION="ACC001"
+MANIFEST_CT_MODALITY="CT"
+MANIFEST_CT_STUDY_ID="STUDY001"
+MANIFEST_CT_STUDY_DESC="CT Abdomen"
+MANIFEST_CT_SERIES_DESC="Axial 5mm"
+
+# ── Patient 2: MR (T1 + T2 series) ──────────────────────────────────────────
+MANIFEST_MR_PATIENT_NAME="SMITH^JANE"
+MANIFEST_MR_PATIENT_ID="PAT002"
+MANIFEST_MR_PATIENT_SEX="F"
+MANIFEST_MR_STUDY_DATE="20240220"
+MANIFEST_MR_ACCESSION="ACC002"
+MANIFEST_MR_MODALITY="MR"
+MANIFEST_MR_STUDY_ID="STUDY002"
+MANIFEST_MR_STUDY_DESC="MR Brain"
+MANIFEST_MR_T1_SERIES_DESC="T1 Axial"
+MANIFEST_MR_T2_SERIES_DESC="T2 Axial"
+
+# ── Patient 3: CR ───────────────────────────────────────────────────────────
+MANIFEST_CR_PATIENT_NAME="WANG^LEI"
+MANIFEST_CR_PATIENT_ID="PAT003"
+MANIFEST_CR_PATIENT_SEX="M"
+MANIFEST_CR_STUDY_DATE="20240310"
+MANIFEST_CR_ACCESSION="ACC003"
+MANIFEST_CR_MODALITY="CR"
+MANIFEST_CR_STUDY_ID="STUDY003"
+MANIFEST_CR_STUDY_DESC="Chest PA"
+MANIFEST_CR_SERIES_DESC="Chest"
+
+# ── Query helpers ───────────────────────────────────────────────────────────
+# A study-date range that spans all three studies (for date-range C-FIND).
+MANIFEST_STUDY_DATE_RANGE="20240101-20240331"
+# Identifiers guaranteed NOT to exist in the dataset, for negative tests.
+MANIFEST_NONEXISTENT_PATIENT_ID="NONEXISTENT"
+MANIFEST_NONEXISTENT_STUDY_UID="1.2.3.999.999.999"

--- a/scripts/generate-test-data.sh
+++ b/scripts/generate-test-data.sh
@@ -8,10 +8,24 @@ set -e
 # Uses OID_ROOT env var for UID generation to avoid collision with clinical data.
 
 OUTPUT_DIR="${1:-${TEST_DATA_DIR:-/dicom/testdata}}"
-OID_ROOT="${OID_ROOT:-1.2.826.0.1.3680043.8.499}"
 GENERATE_PIXEL_DATA="${GENERATE_PIXEL_DATA:-false}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source the fixture manifest (single source of truth for the OID root, UIDs,
+# instance counts, and patient demographics). Installed to /usr/local/bin in
+# the image; alongside in scripts/ for host runs. This also sets OID_ROOT.
+if [ -f "${SCRIPT_DIR}/fixture-manifest.sh" ]; then
+    # shellcheck source=scripts/fixture-manifest.sh
+    source "${SCRIPT_DIR}/fixture-manifest.sh"
+elif [ -f /usr/local/bin/fixture-manifest.sh ]; then
+    # shellcheck source=/usr/local/bin/fixture-manifest.sh
+    source /usr/local/bin/fixture-manifest.sh
+else
+    echo "[generate-test-data] ERROR: fixture-manifest.sh not found" >&2
+    exit 1
+fi
+
 if [ -f "${SCRIPT_DIR}/pixel-data-profile.sh" ]; then
     # shellcheck source=scripts/pixel-data-profile.sh
     source "${SCRIPT_DIR}/pixel-data-profile.sh"
@@ -356,108 +370,108 @@ PIXDUMP
     dump2dcm "${dump_file}" "${output_file}" 2>/dev/null
 }
 
-# ── Patient 1: DOE^JOHN - CT (5 slices) ─────────────
-echo "[generate-test-data] Creating Patient 1: DOE^JOHN (CT, 5 instances)"
+# ── Patient 1: CT ───────────────────────────────────
+echo "[generate-test-data] Creating Patient 1: ${MANIFEST_CT_PATIENT_NAME} (${MANIFEST_CT_MODALITY}, ${MANIFEST_CT_COUNT} instances)"
 
-STUDY_UID="${OID_ROOT}.1.1"
-SERIES_UID="${OID_ROOT}.1.1.1"
+STUDY_UID="${MANIFEST_CT_STUDY_UID}"
+SERIES_UID="${MANIFEST_CT_SERIES_UID}"
 
-for i in $(seq 1 5); do
-    SOP_UID="${OID_ROOT}.1.1.1.${i}"
+for i in $(seq 1 "${MANIFEST_CT_COUNT}"); do
+    SOP_UID="${SERIES_UID}.${i}"
     create_dicom \
         "${OUTPUT_DIR}/ct/ct_pat001_${i}.dcm" \
         "CTImageStorage" \
         "${SOP_UID}" \
-        "DOE^JOHN" \
-        "PAT001" \
-        "M" \
+        "${MANIFEST_CT_PATIENT_NAME}" \
+        "${MANIFEST_CT_PATIENT_ID}" \
+        "${MANIFEST_CT_PATIENT_SEX}" \
         "${STUDY_UID}" \
-        "20240115" \
-        "ACC001" \
-        "CT" \
-        "STUDY001" \
-        "CT Abdomen" \
+        "${MANIFEST_CT_STUDY_DATE}" \
+        "${MANIFEST_CT_ACCESSION}" \
+        "${MANIFEST_CT_MODALITY}" \
+        "${MANIFEST_CT_STUDY_ID}" \
+        "${MANIFEST_CT_STUDY_DESC}" \
         "${SERIES_UID}" \
         "1" \
-        "Axial 5mm" \
+        "${MANIFEST_CT_SERIES_DESC}" \
         "${i}"
 done
 
-# ── Patient 2: SMITH^JANE - MR (2 series x 3) ──────
-echo "[generate-test-data] Creating Patient 2: SMITH^JANE (MR, 6 instances)"
+# ── Patient 2: MR (T1 + T2 series) ──────────────────
+echo "[generate-test-data] Creating Patient 2: ${MANIFEST_MR_PATIENT_NAME} (${MANIFEST_MR_MODALITY}, ${MANIFEST_MR_COUNT} instances)"
 
-STUDY_UID="${OID_ROOT}.2.1"
+STUDY_UID="${MANIFEST_MR_STUDY_UID}"
 
 # Series 1: T1
-SERIES_UID="${OID_ROOT}.2.1.1"
-for i in $(seq 1 3); do
-    SOP_UID="${OID_ROOT}.2.1.1.${i}"
+SERIES_UID="${MANIFEST_MR_T1_SERIES_UID}"
+for i in $(seq 1 "${MANIFEST_MR_T1_COUNT}"); do
+    SOP_UID="${SERIES_UID}.${i}"
     create_dicom \
         "${OUTPUT_DIR}/mr/mr_pat002_s1_${i}.dcm" \
         "MRImageStorage" \
         "${SOP_UID}" \
-        "SMITH^JANE" \
-        "PAT002" \
-        "F" \
+        "${MANIFEST_MR_PATIENT_NAME}" \
+        "${MANIFEST_MR_PATIENT_ID}" \
+        "${MANIFEST_MR_PATIENT_SEX}" \
         "${STUDY_UID}" \
-        "20240220" \
-        "ACC002" \
-        "MR" \
-        "STUDY002" \
-        "MR Brain" \
+        "${MANIFEST_MR_STUDY_DATE}" \
+        "${MANIFEST_MR_ACCESSION}" \
+        "${MANIFEST_MR_MODALITY}" \
+        "${MANIFEST_MR_STUDY_ID}" \
+        "${MANIFEST_MR_STUDY_DESC}" \
         "${SERIES_UID}" \
         "1" \
-        "T1 Axial" \
+        "${MANIFEST_MR_T1_SERIES_DESC}" \
         "${i}"
 done
 
 # Series 2: T2
-SERIES_UID="${OID_ROOT}.2.1.2"
-for i in $(seq 1 3); do
-    SOP_UID="${OID_ROOT}.2.1.2.${i}"
+SERIES_UID="${MANIFEST_MR_T2_SERIES_UID}"
+for i in $(seq 1 "${MANIFEST_MR_T2_COUNT}"); do
+    SOP_UID="${SERIES_UID}.${i}"
     create_dicom \
         "${OUTPUT_DIR}/mr/mr_pat002_s2_${i}.dcm" \
         "MRImageStorage" \
         "${SOP_UID}" \
-        "SMITH^JANE" \
-        "PAT002" \
-        "F" \
+        "${MANIFEST_MR_PATIENT_NAME}" \
+        "${MANIFEST_MR_PATIENT_ID}" \
+        "${MANIFEST_MR_PATIENT_SEX}" \
         "${STUDY_UID}" \
-        "20240220" \
-        "ACC002" \
-        "MR" \
-        "STUDY002" \
-        "MR Brain" \
+        "${MANIFEST_MR_STUDY_DATE}" \
+        "${MANIFEST_MR_ACCESSION}" \
+        "${MANIFEST_MR_MODALITY}" \
+        "${MANIFEST_MR_STUDY_ID}" \
+        "${MANIFEST_MR_STUDY_DESC}" \
         "${SERIES_UID}" \
         "2" \
-        "T2 Axial" \
+        "${MANIFEST_MR_T2_SERIES_DESC}" \
         "${i}"
 done
 
-# ── Patient 3: WANG^LEI - CR (2 images) ─────────────
-echo "[generate-test-data] Creating Patient 3: WANG^LEI (CR, 2 instances)"
+# ── Patient 3: CR ───────────────────────────────────
+echo "[generate-test-data] Creating Patient 3: ${MANIFEST_CR_PATIENT_NAME} (${MANIFEST_CR_MODALITY}, ${MANIFEST_CR_COUNT} instances)"
 
-STUDY_UID="${OID_ROOT}.3.1"
-SERIES_UID="${OID_ROOT}.3.1.1"
+STUDY_UID="${MANIFEST_CR_STUDY_UID}"
+SERIES_UID="${MANIFEST_CR_SERIES_UID}"
 
-for i in $(seq 1 2); do
-    SOP_UID="${OID_ROOT}.3.1.1.${i}"
+for i in $(seq 1 "${MANIFEST_CR_COUNT}"); do
+    SOP_UID="${SERIES_UID}.${i}"
     create_dicom \
         "${OUTPUT_DIR}/cr/cr_pat003_${i}.dcm" \
         "ComputedRadiographyImageStorage" \
         "${SOP_UID}" \
-        "WANG^LEI" \
-        "PAT003" \
-        "M" \
+        "${MANIFEST_CR_PATIENT_NAME}" \
+        "${MANIFEST_CR_PATIENT_ID}" \
+        "${MANIFEST_CR_PATIENT_SEX}" \
         "${STUDY_UID}" \
-        "20240310" \
-        "ACC003" \
-        "CR" \
-        "STUDY003" \
-        "Chest PA" \
+        "${MANIFEST_CR_STUDY_DATE}" \
+        "${MANIFEST_CR_ACCESSION}" \
+        "${MANIFEST_CR_MODALITY}" \
+        "${MANIFEST_CR_STUDY_ID}" \
+        "${MANIFEST_CR_STUDY_DESC}" \
         "${SERIES_UID}" \
         "1" \
-        "Chest" \
+        "${MANIFEST_CR_SERIES_DESC}" \
         "${i}"
 done
 

--- a/tests/test-find.sh
+++ b/tests/test-find.sh
@@ -64,7 +64,7 @@ print_header "C-FIND Query Tests"
 # ── Study-Level Queries ───────────────────────────────
 
 # Test 1: Wildcard patient query (should find >= 3 studies)
-run_find_test "wildcard patient query (STUDY level)" 3 \
+run_find_test "wildcard patient query (STUDY level)" "${MANIFEST_STUDY_COUNT}" \
     findscu -v -aet "${MY_AE}" -aec "${PACS_AE}" \
         -S "${PACS_HOST}" "${PACS_PORT}" \
         -k QueryRetrieveLevel=STUDY \
@@ -76,7 +76,7 @@ run_find_test "specific patient PAT001 (STUDY level)" 1 \
     findscu -v -aet "${MY_AE}" -aec "${PACS_AE}" \
         -S "${PACS_HOST}" "${PACS_PORT}" \
         -k QueryRetrieveLevel=STUDY \
-        -k PatientID="PAT001" \
+        -k PatientID="${MANIFEST_CT_PATIENT_ID}" \
         -k StudyInstanceUID || true
 
 # Test 3: Patient name with wildcard prefix
@@ -84,7 +84,7 @@ run_find_test "patient name DOE* (STUDY level)" 1 \
     findscu -v -aet "${MY_AE}" -aec "${PACS_AE}" \
         -S "${PACS_HOST}" "${PACS_PORT}" \
         -k QueryRetrieveLevel=STUDY \
-        -k PatientName="DOE*" \
+        -k PatientName="${MANIFEST_CT_PATIENT_NAME%%^*}*" \
         -k StudyInstanceUID || true
 
 # Test 4: Query by modality
@@ -92,7 +92,7 @@ run_find_test "modality filter CT (STUDY level)" 1 \
     findscu -v -aet "${MY_AE}" -aec "${PACS_AE}" \
         -S "${PACS_HOST}" "${PACS_PORT}" \
         -k QueryRetrieveLevel=STUDY \
-        -k ModalitiesInStudy="CT" \
+        -k ModalitiesInStudy="${MANIFEST_CT_MODALITY}" \
         -k PatientName \
         -k StudyInstanceUID || true
 
@@ -101,27 +101,27 @@ run_find_test "date filter 20240115 (STUDY level)" 1 \
     findscu -v -aet "${MY_AE}" -aec "${PACS_AE}" \
         -S "${PACS_HOST}" "${PACS_PORT}" \
         -k QueryRetrieveLevel=STUDY \
-        -k StudyDate="20240115" \
+        -k StudyDate="${MANIFEST_CT_STUDY_DATE}" \
         -k PatientName \
         -k StudyInstanceUID || true
 
 # Test 6: Query by date range
-run_find_test "date range 20240101-20240331 (STUDY level)" 3 \
+run_find_test "date range covering all studies (STUDY level)" "${MANIFEST_STUDY_COUNT}" \
     findscu -v -aet "${MY_AE}" -aec "${PACS_AE}" \
         -S "${PACS_HOST}" "${PACS_PORT}" \
         -k QueryRetrieveLevel=STUDY \
-        -k StudyDate="20240101-20240331" \
+        -k StudyDate="${MANIFEST_STUDY_DATE_RANGE}" \
         -k PatientName \
         -k StudyInstanceUID || true
 
 # ── Series-Level Queries ──────────────────────────────
 
 # Test 7: Series within MR study (PAT002 has 2 series: T1 + T2)
-run_find_test "series in MR study PAT002 (SERIES level)" 2 \
+run_find_test "series in MR study PAT002 (SERIES level)" "${MANIFEST_MR_SERIES_COUNT}" \
     findscu -v -aet "${MY_AE}" -aec "${PACS_AE}" \
         -S "${PACS_HOST}" "${PACS_PORT}" \
         -k QueryRetrieveLevel=SERIES \
-        -k StudyInstanceUID="${OID_ROOT}.2.1" \
+        -k StudyInstanceUID="${MANIFEST_MR_STUDY_UID}" \
         -k SeriesInstanceUID \
         -k Modality || true
 
@@ -130,7 +130,7 @@ run_find_test "series in CT study PAT001 (SERIES level)" 1 \
     findscu -v -aet "${MY_AE}" -aec "${PACS_AE}" \
         -S "${PACS_HOST}" "${PACS_PORT}" \
         -k QueryRetrieveLevel=SERIES \
-        -k StudyInstanceUID="${OID_ROOT}.1.1" \
+        -k StudyInstanceUID="${MANIFEST_CT_STUDY_UID}" \
         -k SeriesInstanceUID \
         -k Modality || true
 
@@ -141,7 +141,7 @@ TEST_TOTAL=$((TEST_TOTAL + 1))
 NEG_OUTPUT=$(findscu -v -aet "${MY_AE}" -aec "${PACS_AE}" \
     -S "${PACS_HOST}" "${PACS_PORT}" \
     -k QueryRetrieveLevel=STUDY \
-    -k PatientID="NONEXISTENT" \
+    -k PatientID="${MANIFEST_NONEXISTENT_PATIENT_ID}" \
     -k StudyInstanceUID 2>&1 | tr -d '\0' || true)
 NEG_COUNT=$(count_find_responses "${NEG_OUTPUT}" StudyInstanceUID)
 if [ "${NEG_COUNT}" -eq 0 ]; then

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -27,11 +27,22 @@ fi
 # Set by test-all.sh via environment; individual scripts default to off.
 VERBOSE="${VERBOSE:-false}"
 
-# ── Canonical OID root ────────────────────────────────
-# Single source of truth for the test-data OID root. Must match
-# scripts/generate-test-data.sh and env.default so standalone test
-# scripts query the same UIDs that the generator produces.
-DEFAULT_OID_ROOT="1.2.826.0.1.3680043.8.499"
+# ── Fixture manifest (single source of truth) ─────────
+# Source the shared fixture manifest so every test script inherits the same
+# OID root, UIDs, expected counts, and patient demographics that the data
+# generator (scripts/generate-test-data.sh) produces. Installed to
+# /usr/local/bin in the image; fall back to ../scripts for host-side runs.
+# This also defines DEFAULT_OID_ROOT for back-compat.
+if [ -f /usr/local/bin/fixture-manifest.sh ]; then
+    # shellcheck source=scripts/fixture-manifest.sh
+    source /usr/local/bin/fixture-manifest.sh
+else
+    _helpers_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [ -f "${_helpers_dir}/../scripts/fixture-manifest.sh" ]; then
+        # shellcheck source=scripts/fixture-manifest.sh
+        source "${_helpers_dir}/../scripts/fixture-manifest.sh"
+    fi
+fi
 
 # ── Counters ──────────────────────────────────────────
 TEST_PASSED=0
@@ -228,7 +239,7 @@ ensure_pacs_data() {
         | tr -d '\0' || true)
     existing=$(count_find_responses "${check_output}" StudyInstanceUID)
 
-    if [ "${existing}" -lt 3 ]; then
+    if [ "${existing}" -lt "${MANIFEST_STUDY_COUNT}" ]; then
         echo "Loading test data into PACS..."
         storescu -aet "${my_ae}" -aec "${pacs_ae}" \
             +sd +r "${pacs_host}" "${pacs_port}" "${data_dir}/" >/dev/null 2>&1 || true

--- a/tests/test-move.sh
+++ b/tests/test-move.sh
@@ -61,8 +61,8 @@ fi
 receiver_cleanup_storage "${RECEIVER_STORAGE_DIR}" || exit 1
 
 # ── Test 1: C-MOVE CT study (PAT001, 5 instances) ────
-CT_STUDY_UID="${OID_ROOT}.1.1"
-CT_EXPECTED=5
+CT_STUDY_UID="${MANIFEST_CT_STUDY_UID}"
+CT_EXPECTED="${MANIFEST_CT_COUNT}"
 receiver_cleanup_storage "${RECEIVER_STORAGE_DIR}"
 run_test "retrieve CT study PAT001 to ${STORESCP_AE}" "C-MOVE" \
     movescu -aet "${MY_AE}" -aec "${PACS_AE}" -aem "${STORESCP_AE}" \
@@ -74,8 +74,8 @@ verify_move_count "CT study PAT001 instance count" "${CT_EXPECTED}" "${RECEIVER_
 verify_move_uids  "CT study PAT001 UIDs"           "${CT_STUDY_UID}" "" "${RECEIVER_STORAGE_DIR}" || true
 
 # ── Test 2: C-MOVE MR study (PAT002, 6 instances) ────
-MR_STUDY_UID="${OID_ROOT}.2.1"
-MR_EXPECTED=6
+MR_STUDY_UID="${MANIFEST_MR_STUDY_UID}"
+MR_EXPECTED="${MANIFEST_MR_COUNT}"
 receiver_cleanup_storage "${RECEIVER_STORAGE_DIR}"
 run_test "retrieve MR study PAT002 to ${STORESCP_AE}" "C-MOVE" \
     movescu -aet "${MY_AE}" -aec "${PACS_AE}" -aem "${STORESCP_AE}" \
@@ -87,8 +87,8 @@ verify_move_count "MR study PAT002 instance count" "${MR_EXPECTED}" "${RECEIVER_
 verify_move_uids  "MR study PAT002 UIDs"           "${MR_STUDY_UID}" "" "${RECEIVER_STORAGE_DIR}" || true
 
 # ── Test 3: C-MOVE CR study (PAT003, 2 instances) ────
-CR_STUDY_UID="${OID_ROOT}.3.1"
-CR_EXPECTED=2
+CR_STUDY_UID="${MANIFEST_CR_STUDY_UID}"
+CR_EXPECTED="${MANIFEST_CR_COUNT}"
 receiver_cleanup_storage "${RECEIVER_STORAGE_DIR}"
 run_test "retrieve CR study PAT003 to ${STORESCP_AE}" "C-MOVE" \
     movescu -aet "${MY_AE}" -aec "${PACS_AE}" -aem "${STORESCP_AE}" \
@@ -107,7 +107,7 @@ TEST_TOTAL=$((TEST_TOTAL + 1))
 MOVE_OUTPUT=$(movescu -v -aet "${MY_AE}" -aec "${PACS_AE}" -aem "${STORESCP_AE}" \
     -S "${PACS_HOST}" "${PACS_PORT}" \
     -k QueryRetrieveLevel=STUDY \
-    -k StudyInstanceUID="1.2.3.999.999.999" 2>&1 || true)
+    -k StudyInstanceUID="${MANIFEST_NONEXISTENT_STUDY_UID}" 2>&1 || true)
 
 if echo "${MOVE_OUTPUT}" | grep -qi "error\|refused\|abort" 2>/dev/null; then
     print_fail "C-MOVE: nonexistent study (unexpected error)"
@@ -121,8 +121,8 @@ verify_move_count "nonexistent study leaves receiver empty" 0 "${RECEIVER_STORAG
 
 # ── Test 5: C-MOVE at SERIES level ───────────────────
 # Retrieve only the T1 series from PAT002's MR study (3 instances).
-T1_SERIES_UID="${OID_ROOT}.2.1.1"
-T1_EXPECTED=3
+T1_SERIES_UID="${MANIFEST_MR_T1_SERIES_UID}"
+T1_EXPECTED="${MANIFEST_MR_T1_COUNT}"
 receiver_cleanup_storage "${RECEIVER_STORAGE_DIR}"
 run_test "retrieve MR T1 series (SERIES level) to ${STORESCP_AE}" "C-MOVE" \
     movescu -aet "${MY_AE}" -aec "${PACS_AE}" -aem "${STORESCP_AE}" \

--- a/tests/test-store.sh
+++ b/tests/test-store.sh
@@ -93,12 +93,12 @@ FIND_OUTPUT=$(findscu -v -aet "${MY_AE}" -aec "${PACS_AE}" \
     -k StudyInstanceUID 2>&1 | tr -d '\0' || true)
 
 STUDY_COUNT=$(count_find_responses "${FIND_OUTPUT}" StudyInstanceUID)
-if [ "${STUDY_COUNT}" -ge 3 ]; then
-    print_pass "C-STORE: verification via C-FIND (found ${STUDY_COUNT} studies, expected >= 3)"
-    print_verbose "Stored ${TOTAL_FILES} files across 3 patients"
+if [ "${STUDY_COUNT}" -ge "${MANIFEST_STUDY_COUNT}" ]; then
+    print_pass "C-STORE: verification via C-FIND (found ${STUDY_COUNT} studies, expected >= ${MANIFEST_STUDY_COUNT})"
+    print_verbose "Stored ${TOTAL_FILES} files across ${MANIFEST_STUDY_COUNT} studies"
     TEST_PASSED=$((TEST_PASSED + 1))
 else
-    print_fail "C-STORE: verification via C-FIND (found ${STUDY_COUNT} studies, expected >= 3)"
+    print_fail "C-STORE: verification via C-FIND (found ${STUDY_COUNT} studies, expected >= ${MANIFEST_STUDY_COUNT})"
     TEST_FAILED=$((TEST_FAILED + 1))
 fi
 


### PR DESCRIPTION
## Summary

Phase 2 of broadening dcmtk-docker toward a general-purpose test PACS: decouples the test suite from hardcoded synthetic fixtures so it can be pointed at a foreign / non-DCMTK PACS without rewriting assertions. Closes #51.

## Changes

- **`scripts/fixture-manifest.sh`** (new) — single source of truth for the synthetic dataset identity: OID root, study/series UIDs, instance counts, patient demographics. Placed in `scripts/` (copied to `/usr/local/bin`) so both the PACS and test-client containers can source it.
- **`generate-test-data.sh`** — derives all UIDs and metadata from the manifest instead of hardcoding them.
- **`test-find.sh` / `test-move.sh`** — replace hardcoded `StudyInstanceUID`s, instance counts, and demographics with manifest variables.
- **`test-store.sh` / `test-helpers.sh`** — replace the magic study-count `3` with `MANIFEST_STUDY_COUNT`.
- **README** — documents retargeting the suite at an external PACS via `OID_ROOT` + `PACS_HOST`/`PACS_AE_TITLE`.

## Verification

- Host (DCMTK 3.7.0): `OID_ROOT=9.8.7.test` produces `StudyInstanceUID 9.8.7.test.1.1`, `SOPInstanceUID 9.8.7.test.2.1.1.2`, and 13 instances — confirming the generator follows the manifest.
- `bash -n` clean on all touched scripts.
- CI (`test-isolation.yml`) exercises the full DIMSE suite against the manifest-driven data, guarding against regression.

## Out of scope (tracked as later phases)

Modality Worklist (MWL), ad-hoc C-MOVE destinations, TLS profile.