### PR TITLE
fix(tests): track per-suite exit codes in test-all.sh and run it in CI

### DIFF
--- a/.github/workflows/test-isolation.yml
+++ b/.github/workflows/test-isolation.yml
@@ -333,6 +333,99 @@ jobs:
         if: always()
         run: docker compose down -v
 
+  test-aggregator:
+    name: test-all.sh aggregator (green-on-failure guard)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Stage .env from defaults
+        run: cp env.default .env
+
+      - name: Build and start stack
+        run: |
+          docker compose up -d --build
+          sleep 5
+
+      - name: Wait for all SCP services to be healthy
+        run: |
+          services="pacs-server pacs-server-2 storescp-receiver mwl-server"
+          for i in $(seq 1 60); do
+            pending=""
+            for svc in $services; do
+              cid=$(docker compose ps -q "$svc" 2>/dev/null | head -n1)
+              if [ -n "$cid" ]; then
+                status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid" 2>/dev/null || echo "starting")
+              else
+                status="starting"
+              fi
+              if [ "$status" != "healthy" ]; then
+                pending="$pending $svc=$status"
+              fi
+            done
+            if [ -z "$pending" ]; then
+              echo "All SCP services are healthy"
+              exit 0
+            fi
+            echo "waiting for SCP services (attempt $i/60, pending:$pending)"
+            sleep 2
+          done
+          echo "ERROR: not all SCP services became healthy in time"
+          for svc in $services; do
+            cid=$(docker compose ps -q "$svc" 2>/dev/null | head -n1)
+            if [ -n "$cid" ]; then
+              status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid" 2>/dev/null || echo "missing")
+            else
+              status="missing"
+            fi
+            if [ "$status" != "healthy" ]; then
+              echo "=== $svc not healthy (status: $status); logs ==="
+              docker compose logs --tail=100 "$svc" || true
+            fi
+          done
+          exit 1
+
+      - name: Wipe PACS storage so the aggregator's C-STORE suite starts empty
+        # test-all.sh runs test-store.sh, which requires an empty PACS
+        # (ensure_clean_pacs) so its >= 3 study-count check is meaningful. The
+        # entrypoint indexes synthetic data on first boot, so wipe on the host
+        # and recreate the .indexed marker -- exactly like the isolated
+        # test-store jobs. See scripts/entrypoint.sh.
+        run: |
+          for svc in pacs-server pacs-server-2; do
+            docker compose exec -T "$svc" sh -c '
+              find /dicom/db -mindepth 1 -delete 2>/dev/null || true
+              mkdir -p "/dicom/db/${AE_TITLE}"
+              touch "/dicom/db/${AE_TITLE}/.indexed"
+            '
+          done
+          docker compose restart pacs-server pacs-server-2
+          for i in $(seq 1 60); do
+            status=$(docker inspect -f '{{.State.Health.Status}}' pacs-server 2>/dev/null || echo "starting")
+            if [ "$status" = "healthy" ]; then
+              echo "pacs-server healthy after cleanup"
+              break
+            fi
+            sleep 2
+          done
+
+      - name: Run the full aggregator and assert exit 0
+        # Exercises test-all.sh's own verdict logic (the SUITES_FAILED gate),
+        # which the per-script isolation jobs never cover. A green-on-failure
+        # regression in the aggregator would fail this job.
+        run: docker compose exec -T test-client /tests/test-all.sh
+
+      - name: Dump logs on failure
+        if: failure()
+        run: |
+          docker compose logs pacs-server || true
+          docker compose logs test-client || true
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose down -v
+
   # NOTE: there is intentionally no TLS CI job. The stock Debian apt dcmtk
   # package is not linked against OpenSSL, so dcmqrscp rejects +tls
   # ("Unknown option +tls"). The TLS profile (docker-compose.tls.yml) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synced the README CLI command table and Project Structure tree with the actual `pacs.sh` subcommands and on-disk file layout.
 
 ### Fixed
+- `tests/test-all.sh` no longer reports "ALL TESTS PASSED" when a suite aborts at the process level (non-zero exit) without emitting `[FAIL]` markers. The aggregator now tracks per-suite exit codes (`SUITES_FAILED`) independently of the parsed `[PASS]`/`[FAIL]` counts, treats a missing suite script as a failure rather than a silent skip, and gates its final verdict on both signals. A new `test-aggregator` CI job runs the aggregator against a fresh stack so its own verdict logic is under test. (#60)
 - TLS overlay no longer deadlocks the stack on a non-TLS-capable image. When `TLS_ENABLED=true` but the `dcmqrscp` build lacks `+tls`, the entrypoint now fails fast (`exit 1`) with an explicit error instead of falling through to cleartext while the overlay healthcheck hung on `echoscu +tls` — which previously left `pacs-server` permanently unhealthy and blocked `test-client` from starting (#59).
 
 ### Security

--- a/tests/test-all.sh
+++ b/tests/test-all.sh
@@ -38,6 +38,11 @@ PACS_AE="${PACS_AE_TITLE:-DCMTK_PACS}"
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 TOTAL_TESTS=0
+# Process-level failures: a suite that aborts non-zero (e.g. a set -e mid-suite
+# abort or an unreachable-SCP preamble) without printing any [FAIL] marker would
+# otherwise leave TOTAL_FAILED at 0 and be masked as a pass. Tracked separately
+# from the parsed [PASS]/[FAIL] counts and folded into the final verdict.
+SUITES_FAILED=0
 SUITE_RESULTS=""
 
 # ── Banner ────────────────────────────────────────────
@@ -78,7 +83,10 @@ run_suite() {
     local script="$2"
 
     if [ ! -f "${script}" ]; then
-        printf "${C_RED}[SKIP]${C_RESET} %s: script not found (%s)\n" "${name}" "${script}"
+        # A missing suite is a regression, not a benign skip: count it so the
+        # aggregate fails rather than silently dropping coverage.
+        printf "${C_RED}[FAIL]${C_RESET} %s: script not found (%s)\n" "${name}" "${script}"
+        SUITES_FAILED=$((SUITES_FAILED + 1))
         return
     fi
 
@@ -109,7 +117,10 @@ run_suite() {
     if [ "${exit_code}" -eq 0 ]; then
         SUITE_RESULTS="${SUITE_RESULTS}$(printf "  ${C_GREEN}[PASS]${C_RESET} %s: %d/%d passed\n" "${name}" "${passed}" "${total}")\n"
     else
-        SUITE_RESULTS="${SUITE_RESULTS}$(printf "  ${C_RED}[FAIL]${C_RESET} %s: %d/%d passed, %d failed\n" "${name}" "${passed}" "${total}" "${failed}")\n"
+        # Record the process-level failure even if the suite printed no [FAIL]
+        # markers (e.g. it aborted under set -e before any assertion ran).
+        SUITE_RESULTS="${SUITE_RESULTS}$(printf "  ${C_RED}[FAIL]${C_RESET} %s: %d/%d passed, %d failed (exit %d)\n" "${name}" "${passed}" "${total}" "${failed}" "${exit_code}")\n"
+        SUITES_FAILED=$((SUITES_FAILED + 1))
     fi
 }
 
@@ -134,11 +145,18 @@ if [ "${TOTAL_FAILED}" -gt 0 ]; then
     printf ", ${C_RED}%d failed${C_RESET}" "${TOTAL_FAILED}"
 fi
 echo ""
+if [ "${SUITES_FAILED}" -gt 0 ]; then
+    printf "  ${C_RED}Suites aborted/failed at the process level: %d${C_RESET}\n" "${SUITES_FAILED}"
+fi
 printf "${C_BOLD}========================================${C_RESET}\n"
 echo ""
 
-if [ "${TOTAL_FAILED}" -gt 0 ]; then
-    printf "${C_RED}RESULT: FAILED${C_RESET}\n"
+if [ "${TOTAL_FAILED}" -gt 0 ] || [ "${SUITES_FAILED}" -gt 0 ]; then
+    printf "${C_RED}RESULT: FAILED${C_RESET}"
+    if [ "${SUITES_FAILED}" -gt 0 ]; then
+        printf "${C_RED} (%d suite(s) aborted or failed at the process level)${C_RESET}" "${SUITES_FAILED}"
+    fi
+    printf "\n"
     exit 1
 else
     printf "${C_GREEN}RESULT: ALL TESTS PASSED${C_RESET}\n"


### PR DESCRIPTION
## Summary
Closes the green-on-failure gap in the top-level aggregator (audit finding **H2** + coverage gap **M5**, issue #60).

`tests/test-all.sh` derived its verdict only from parsed `[FAIL]` lines (`TOTAL_FAILED`). A suite that aborts non-zero **without** printing a `[FAIL]` marker — a `set -e` mid-suite abort, or the `ensure_scp_reachable` preamble printing only `ERROR ... NOT reachable` — left `TOTAL_FAILED` at 0 and was reported as `ALL TESTS PASSED` (exit 0). All seven dispatched suites use `set -euo pipefail`, so the masking covered any marker-less abort. The aggregator's own verdict logic was also run by no CI job.

## Change
- **`tests/test-all.sh`**
  - New `SUITES_FAILED` counter, incremented in `run_suite` whenever a suite exits non-zero — independently of the parsed `[PASS]`/`[FAIL]` counts.
  - A missing suite script is now a failure (`SUITES_FAILED++`) rather than a silent `[SKIP]`, so dropped coverage surfaces.
  - Final verdict gated on `(TOTAL_FAILED > 0 || SUITES_FAILED > 0)`; the summary reports any process-level failures.
- **`.github/workflows/test-isolation.yml`** — new `test-aggregator` job that runs `test-all.sh` against a fresh stack and asserts exit 0. It wipes PACS storage first (recreating the `.indexed` marker) so the embedded `test-store.sh` starts from an empty PACS, exactly like the isolated `test-store` jobs.
- **`CHANGELOG.md`** — `### Fixed` entry.

## How the masked path is now caught
- **Before:** marker-less abort → `passed=0, failed=0` → `TOTAL_FAILED` unchanged → exit 0 (masked).
- **After:** marker-less abort → `exit_code != 0` → `SUITES_FAILED++` → final gate trips → exit 1.

Trace: `run_suite` captures `exit_code` at the `output=$(bash "${script}" 2>&1) || exit_code=$?` line; the non-zero branch now increments `SUITES_FAILED`; the final `if` ORs it into the verdict.

## Verification
- `bash -n tests/test-all.sh` — OK.
- Workflow YAML parses; `jobs` now include `test-aggregator`.
- The new CI job runs the aggregator end-to-end on ubuntu (the local Docker daemon is unavailable in this environment).

## Acceptance criteria (#60)
- [x] Per-suite exit codes tracked independently of output parsing (`SUITES_FAILED`).
- [x] Final exit gated on `(TOTAL_FAILED > 0 || SUITES_FAILED > 0)`.
- [x] Marker-less aborting suite now fails the aggregate (trace above; the `test-aggregator` job guards the happy path).
- [x] A CI job runs `tests/test-all.sh` against a fresh stack and asserts exit 0.

Closes #60 (manual close after merge to `develop`; GitHub auto-close fires only on `main`).
