### PR TITLE
chore(security): drop all caps and forbid privilege escalation on DICOM services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TLS overlay no longer deadlocks the stack on a non-TLS-capable image. When `TLS_ENABLED=true` but the `dcmqrscp` build lacks `+tls`, the entrypoint now fails fast (`exit 1`) with an explicit error instead of falling through to cleartext while the overlay healthcheck hung on `echoscu +tls` — which previously left `pacs-server` permanently unhealthy and blocked `test-client` from starting (#59).
 
 ### Security
+- Added `cap_drop: [ALL]` and `security_opt: [no-new-privileges:true]` to the four network-facing services (`pacs-server`, `pacs-server-2`, `storescp-receiver`, `mwl-server`) as defence-in-depth atop the non-root user; the high-port DICOM listeners need no Linux capabilities. A read-only root filesystem is deferred (documented in `docker-compose.yml`) because the entrypoint renders config to `/tmp` and DCMTK tools use temp files. (#64)
 - Reduced privilege of the network-facing DICOM services (non-root) and bounded per-container resource usage, lowering blast radius when the stack is wired into a downstream test loop.
 
 ## [0.1.0] - 2026-05-30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,15 @@ services:
     build: .
     mem_limit: ${DICOM_MEM_LIMIT:-512m}
     cpus: ${DICOM_CPUS:-1.0}
+    # Defence-in-depth on top of the non-root 'pacs' user: drop all Linux
+    # capabilities (the DICOM listener binds a high port, so none are needed)
+    # and forbid privilege escalation. A read_only root filesystem is deferred:
+    # the entrypoint renders the config to /tmp and several DCMTK tools use
+    # temp files, so it would need tmpfs mounts to be added safely.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     environment:
       - ROLE=pacs-server
       - AE_TITLE=${PACS1_AE_TITLE:-DCMTK_PACS}
@@ -54,6 +63,10 @@ services:
     build: .
     mem_limit: ${DICOM_MEM_LIMIT:-512m}
     cpus: ${DICOM_CPUS:-1.0}
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     environment:
       - ROLE=pacs-server
       - AE_TITLE=${PACS2_AE_TITLE:-DCMTK_PAC2}
@@ -93,6 +106,10 @@ services:
     build: .
     mem_limit: ${DICOM_MEM_LIMIT:-512m}
     cpus: ${DICOM_CPUS:-1.0}
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     environment:
       - ROLE=storescp
       - AE_TITLE=${STORESCP_AE_TITLE:-STORE_SCP}
@@ -120,6 +137,10 @@ services:
     build: .
     mem_limit: ${DICOM_MEM_LIMIT:-512m}
     cpus: ${DICOM_CPUS:-1.0}
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     environment:
       - ROLE=worklist
       - AE_TITLE=${WLM_AE_TITLE:-DCMTK_WLM}


### PR DESCRIPTION
## Summary
Adds container-hardening primitives to the network-facing DICOM services (audit finding **L1**, issue #64).

## Change
- `cap_drop: [ALL]` + `security_opt: [no-new-privileges:true]` on `pacs-server`, `pacs-server-2`, `storescp-receiver`, `mwl-server`.
- `test-client` (root, no published ports) is intentionally left as-is.
- `read_only` root filesystem deferred and documented in `docker-compose.yml` (entrypoint renders config to `/tmp`; DCMTK tools use temp files).
- `CHANGELOG.md` Security entry.

## Why this is safe
The listeners bind high ports (11112) as the non-root `pacs` user, so none of them need `CAP_NET_BIND_SERVICE` or any other capability. Dropping all caps therefore changes no functional behaviour — verified by the full isolation + aggregator CI matrix on this PR, where every suite runs under the hardened services.

## Verification
- `docker-compose.yml` parses; the four services carry `cap_drop:[ALL]` + `no-new-privileges`, `test-client` does not.
- Functional behaviour covered by the CI matrix.

## Acceptance criteria (#64)
- [x] `no-new-privileges` + `cap_drop:[ALL]` on the four network-facing services.
- [x] `read_only` deferred with a documented reason.
- [x] Stack still passes the test suite (CI matrix on this PR).

Closes #64 (manual close after merge to `develop`; GitHub auto-close fires only on `main`).
