### PR TITLE
docs(release): record main branch protection now enabled (#82)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,10 +43,15 @@ what the changelog describes.
 - Commit messages, issues, and PRs are in English (documents may be Korean); no
   AI attribution.
 
-> **Follow-up:** as of this writing `main` is **not yet protected**
-> (`gh api repos/kcenon/dcmtk-docker/branches/main/protection` returns 404).
-> Enable protection before relying on this process — at minimum require a pull
-> request and forbid force-pushes and branch deletion. This needs admin rights.
+> **Protection status:** `main` is protected (enabled 2026-05-31, issue #82).
+> A pull request is required before merging (0 required approvals, so a solo
+> maintainer is not locked out), force-pushes and branch deletion are forbidden,
+> and the full CI matrix is required and must be up to date before merge
+> (`strict`): the twelve isolation/aggregator/security checks that the
+> `develop`→`main` promotion runs (see #81). Protection is intentionally not
+> enforced against admins (`enforce_admins: false`, mirroring `develop`), so the
+> owner retains an emergency-merge path. Inspect the live rules with
+> `gh api repos/kcenon/dcmtk-docker/branches/main/protection`.
 
 ## Verifying after a release
 


### PR DESCRIPTION
## Summary
Resolves issue #82 (the lone open follow-up from the 0.2.0 release epic #70). `main` was the published default branch but was **unprotected** (`branches/main/protection` returned 404), contradicting the invariant `RELEASE.md` already declared. This PR records the now-applied protection and removes that claim-vs-reality gap.

## What was done (outside this diff)
Branch protection was enabled on `main` via the API:
- **Require a pull request before merging** — `required_pull_request_reviews` with `required_approving_review_count: 0` (a PR is mandatory; no approval needed, so a solo maintainer is not locked out).
- **Forbid force-pushes and branch deletion** — `allow_force_pushes: false`, `allow_deletions: false`.
- **Required status checks (strict)** — the **full current 12-job CI matrix** that the `develop`→`main` promotion already runs (verified on #81), not the pre-0.2.0 subset. `strict: true` requires the branch to be up to date before merge.
- **`enforce_admins: false`** — mirrors `develop`; the owner keeps an emergency-merge path.

## This diff
Replaces the `RELEASE.md` "as of this writing `main` is not yet protected (404)" follow-up note with a **Protection status** note describing the live configuration, so the document and the repository now agree.

## Acceptance criteria (#82)
- [x] Enable branch protection on `main` (PR required, force-push + deletion forbidden).
- [x] Decide required status checks — the full 12-check matrix from #81.
- [x] Update the `RELEASE.md` follow-up note once protection is in place.

## Note
Docs-only change → the CI test matrix is not triggered (path filters), as with the earlier `RELEASE.md` work (#79). Merges to `develop`; `main`'s copy inherits this note at the next release promotion. A separate finding (develop's required-checks list is stale at 7 of 12) is reported on the issue, not changed here.