### PR TITLE
docs: correct TLS fail-fast doc drift in docs/04 and entrypoint

### DIFF
--- a/docs/04_work_plan.md
+++ b/docs/04_work_plan.md
@@ -525,11 +525,12 @@ docker compose down -v
 | DICOMweb | No | No (not a DCMTK feature) |
 | JSON export | Limited | Improved |
 
-> Correction (verified in CI): the Debian Bookworm apt `dcmtk` package is **not**
-> linked against OpenSSL, so `dcmqrscp +tls` fails with "Unknown option +tls".
-> TLS therefore requires a TLS-capable (source-built / OpenSSL-linked) dcmtk
-> image; the shipped TLS profile detects this at runtime and falls back to
-> cleartext. All other planned functionality works on the apt build.
+> Correction (TLS skip path verified in CI): the Debian Bookworm apt `dcmtk`
+> package is **not** linked against OpenSSL, so `dcmqrscp +tls` fails with
+> "Unknown option +tls". TLS therefore requires a TLS-capable (source-built /
+> OpenSSL-linked) dcmtk image; the shipped TLS profile refuses to start (exit 1)
+> rather than silently downgrading to cleartext. All other planned functionality
+> works on the apt build.
 
 ### Platform-Specific Concerns
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -110,8 +110,8 @@ start_pacs_server() {
 
     # TLS profile: serve over an authenticated secure connection. This requires a
     # dcmqrscp built with OpenSSL (+tls). The stock Debian apt dcmtk package is
-    # NOT linked against OpenSSL, so we detect support at runtime and fall back to
-    # cleartext (with a clear warning) rather than crash-looping. Use a TLS-capable
+    # NOT linked against OpenSSL, so we detect support at runtime and refuse to
+    # start (exit 1) rather than silently downgrading to cleartext. Use a TLS-capable
     # (source-built / OpenSSL-linked) dcmtk image to actually serve TLS.
     if [ "${TLS_ENABLED:-false}" = "true" ]; then
         if dcmqrscp --help 2>&1 | grep -q -- '--enable-tls'; then


### PR DESCRIPTION
## What

Correct a three-way doc/code drift around the TLS profile's failure behavior.

- `docs/04_work_plan.md`: change the DCMTK version-compatibility note so it says the shipped TLS profile **refuses to start (exit 1) rather than silently downgrading to cleartext** (it previously claimed runtime detection + fallback to cleartext, the opposite of the code).
- `docs/04_work_plan.md`: scope the `> Correction (verified in CI)` label to `> Correction (TLS skip path verified in CI)` — the `test-tls-skip` job is real, so the true part is kept rather than deleted.
- `scripts/entrypoint.sh`: fix the stale comment that said it would "fall back to cleartext ... rather than crash-looping", which contradicted the `exit 1` fail-fast block directly below it.

### Change Type
- [x] Documentation
- [x] Bugfix (stale comment vs code)

## Why

`CHANGELOG.md` already claims `docs/04_work_plan.md` was "corrected accordingly" and that the "verified in CI" wording was fixed, but #66 only corrected `docs/05_usage_guide.md` and the CHANGELOG — it missed `docs/04`. That left a contradiction between the code (`exit 1` fail-fast), the CHANGELOG (self-correction claim), and the design doc. Fixing `docs/04` makes the existing CHANGELOG claim true; no CHANGELOG edit is needed.

## Where

| File | Change |
|------|--------|
| `docs/04_work_plan.md` | Compatibility note: fail-fast wording + scoped CI label |
| `scripts/entrypoint.sh` | TLS-profile comment aligned with `exit 1` behavior |

## How

- Wording now matches `docs/05_usage_guide.md:551-553` ("refuses to start (exit 1) ... rather than silently downgrading to cleartext") and `scripts/entrypoint.sh` (`log_error ... exit 1`).
- `bash -n scripts/entrypoint.sh` passes (comment-only change).
- Surgical: only the drifted lines are touched; CHANGELOG and adjacent docs are unchanged.

## Related

Closes #85
Part of #91
Completes #66 (TLS documentation alignment), which corrected `docs/05` and the CHANGELOG but missed `docs/04`.
