### PR TITLE
docs: clarify restricted-mode boundaries and add PACS_BIND_ADDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,7 @@ cp env.default .env
 | `STORESCP_AE_TITLE` | `STORE_SCP` | Store SCP receiver AE Title |
 | `STORESCP_HOST_PORT` | `11114` | Store SCP receiver host port |
 | `TEST_SCU_AE_TITLE` | `TEST_SCU` | Test client AE Title |
+| `PACS_BIND_ADDR` | `0.0.0.0` | Host interface the published ports bind to. Set to e.g. `127.0.0.1` to expose ports only to the local host (see Security Notes) |
 | `DICOM_PORT` | `11112` | Internal container DICOM port |
 | `MAX_PDU_SIZE` | `16384` | Maximum PDU size (bytes) |
 | `MAX_ASSOCIATIONS` | `16` | Maximum concurrent associations |
@@ -568,6 +569,48 @@ Even with a peer whitelist, a production deployment should add:
 - **Access reviews**: Periodically audit the HostTable; remove
   decommissioned peers and rotate AE Titles when needed.
 
+### Restricting the published bind address
+
+By default every published DICOM port binds to all host interfaces
+(`0.0.0.0`). Docker programs its own iptables rules for published ports,
+which **bypass host-level firewalls such as `ufw`**, so a port published
+on `0.0.0.0` is reachable from any network the host can see.
+
+The `PACS_BIND_ADDR` environment variable controls the host interface
+the four published ports bind to:
+
+```
+ports:
+  - "${PACS_BIND_ADDR:-0.0.0.0}:${PACS1_HOST_PORT:-11112}:11112"
+```
+
+The default `0.0.0.0` preserves the original behavior (CI and the test
+suite reach the services over the Docker network, not host ports, so the
+default keeps them green). For any deployment that touches a non-isolated
+network, set `PACS_BIND_ADDR` in your `.env` to a single trusted
+interface — typically loopback — and reach the stack through a reverse
+proxy or SSH tunnel:
+
+```bash
+# .env: only expose the published ports to the local host
+PACS_BIND_ADDR=127.0.0.1
+```
+
+Combine this with a firewall and/or a TLS-terminating reverse proxy that
+enforces peer identity. Note: a secure-by-default `127.0.0.1` bind is a
+behavior change and is intentionally **not** the shipped default; it is
+tracked separately.
+
+#### Concurrency is bounded at the network boundary, not per-service
+
+`storescp` (`storescp-receiver`) and `wlmscpfs` (`mwl-server`) are
+single-process sequential receivers, and DCMTK provides no
+concurrent-association cap flag for them — there is no per-service knob
+to invent here. Bound their exposure with the network boundary above
+(firewall / reverse proxy / restricted `PACS_BIND_ADDR`) rather than a
+DCMTK option. `dcmqrscp` does cap concurrency via its existing
+`MaxAssociations` setting (`MAX_ASSOCIATIONS`, default 16).
+
 ### Restricted AE whitelist profile (opt-in)
 
 For test runs that need to exercise production-like access control
@@ -583,6 +626,27 @@ The `restricted` profile keeps the same HostTable entries used by the
 test suite (`test_client`, `store_scp`, sibling PACS), so the default
 test data path still works. Any Calling AE Title outside that list is
 rejected at association setup.
+
+#### What restricted mode does NOT cover
+
+Restricted mode is **not** a stack-wide authentication switch. It swaps
+only the two `dcmqrscp` config templates, so it protects **only the
+dcmqrscp query/retrieve entry** (the primary and secondary PACS
+servers). The other DICOM-facing services remain unauthenticated in
+**every** mode, including restricted:
+
+- **`storescp-receiver`** accepts unauthenticated C-STORE from any peer.
+  Its `--aetitle` flag sets the receiver's own Called AE Title; it is
+  **not** a Calling-AE whitelist and does not restrict who may connect.
+- **`mwl-server`** (`wlmscpfs`) accepts unauthenticated C-FIND from any
+  peer and has no Calling-AE access control. A Modality Worklist query
+  returns scheduled-procedure and patient demographic data (PHI), so any
+  unauthenticated C-FIND can read the worklist.
+
+If you need to restrict these services, place a network boundary in
+front of them (firewall, private VLAN, or a TLS-terminating reverse
+proxy that enforces peer identity). DCMTK's `storescp` and `wlmscpfs`
+do not provide a built-in Calling-AE whitelist.
 
 ```bash
 # Start the stack in restricted (whitelist) mode

--- a/config/dcmqrscp-production.cfg.example
+++ b/config/dcmqrscp-production.cfg.example
@@ -40,13 +40,25 @@ MaxAssociations = 16
 # Replace each entry below with a real modality / viewer / archive.
 # The "all_peers" line aggregates them into a single whitelist that the
 # AETable references by name.
+#
+# IMPORTANT - self and sibling PACS for C-MOVE:
+#   C-MOVE requires the move *destination* AE to resolve through the same
+#   HostTable / peer group. If you operate more than one PACS node, or expect
+#   a node to C-MOVE to itself, you MUST register the self AE (the AETable
+#   entry below, here PROD_PACS) and every sibling PACS in the HostTable and
+#   include them in "all_peers". Omitting them yields "no matching
+#   destination" / unknown move destination errors at C-MOVE time. The
+#   self_pacs / sibling_pacs rows below are examples; replace the AE Titles,
+#   hostnames, and ports with your real nodes.
 HostTable BEGIN
   modality_ct1   = (CT_SCANNER_01,  ct1.hospital.example,         11112)
   modality_mr1   = (MR_SCANNER_01,  mr1.hospital.example,         11112)
   viewer_main    = (PACS_VIEWER,    viewer.hospital.example,      11112)
   archive_dr     = (DR_ARCHIVE,     archive.dr.hospital.example,  11112)
+  self_pacs      = (PROD_PACS,      pacs1.hospital.example,       11112)
+  sibling_pacs   = (PROD_PACS_2,    pacs2.hospital.example,       11112)
 
-  all_peers      = modality_ct1, modality_mr1, viewer_main, archive_dr
+  all_peers      = modality_ct1, modality_mr1, viewer_main, archive_dr, self_pacs, sibling_pacs
 HostTable END
 
 # VendorTable: optional grouping by vendor or department.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       # Ad-hoc C-MOVE destinations: "name=AE:host:port ..." (empty = none)
       - EXTRA_PEERS=${EXTRA_PEERS:-}
     ports:
-      - "${PACS1_HOST_PORT:-11112}:11112"
+      - "${PACS_BIND_ADDR:-0.0.0.0}:${PACS1_HOST_PORT:-11112}:11112"
     volumes:
       - pacs-data:/dicom/db
       - ./config:/etc/dcmtk:ro
@@ -86,7 +86,7 @@ services:
       # Ad-hoc C-MOVE destinations: "name=AE:host:port ..." (empty = none)
       - EXTRA_PEERS=${EXTRA_PEERS:-}
     ports:
-      - "${PACS2_HOST_PORT:-11113}:11112"
+      - "${PACS_BIND_ADDR:-0.0.0.0}:${PACS2_HOST_PORT:-11113}:11112"
     volumes:
       - pacs2-data:/dicom/db
       - ./config:/etc/dcmtk:ro
@@ -117,7 +117,7 @@ services:
       - STORAGE_DIR=/dicom/received
       - LOG_LEVEL=${LOG_LEVEL:-info}
     ports:
-      - "${STORESCP_HOST_PORT:-11114}:11112"
+      - "${PACS_BIND_ADDR:-0.0.0.0}:${STORESCP_HOST_PORT:-11114}:11112"
     volumes:
       - received-data:/dicom/received
     networks:
@@ -151,7 +151,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - OID_ROOT=${OID_ROOT:-1.2.826.0.1.3680043.8.499}
     ports:
-      - "${WLM_HOST_PORT:-11115}:11112"
+      - "${PACS_BIND_ADDR:-0.0.0.0}:${WLM_HOST_PORT:-11115}:11112"
     volumes:
       - worklist-data:/dicom/worklist
     networks:

--- a/env.default
+++ b/env.default
@@ -25,6 +25,12 @@ WLM_STATION_AE=MODALITY01
 TEST_SCU_AE_TITLE=TEST_SCU
 
 # -- Shared Settings --
+# Host interface the published DICOM ports bind to. The default 0.0.0.0 binds
+# every host port to all interfaces, preserving the original behavior. For a
+# non-isolated deployment, bind to a single interface (e.g. 127.0.0.1) and/or
+# place the stack behind a firewall or reverse proxy. See README "Security
+# Notes" -> "Restricting the published bind address".
+PACS_BIND_ADDR=0.0.0.0
 DICOM_PORT=11112
 MAX_PDU_SIZE=16384
 MAX_ASSOCIATIONS=16


### PR DESCRIPTION
## What

Clarifies the restricted-mode security boundary, introduces a configurable
bind address, and fills the production config example gaps surfaced by the
post-0.2.0 audit (issue #87). Documentation/config only — no behavior change
to the shipped defaults.

### Change Type
- [x] Documentation
- [x] Chore (config)

### Affected Components
- `README.md` — Security Notes
- `docker-compose.yml` — four `ports` mappings
- `env.default` — new `PACS_BIND_ADDR`
- `config/dcmqrscp-production.cfg.example` — HostTable

## Why

The security-boundary docs and the production config example understated the
access-control model. The unauthenticated `ANY` default is an intentional
test-PACS design, but the boundaries must be explicit for anyone adapting it
toward production.

- **H5 — restricted asymmetry**: restricted mode swaps only the two dcmqrscp
  templates; `storescp-receiver` and `mwl-server` have no access control in
  any mode, and MWL returns schedule/patient PHI to any unauthenticated
  C-FIND. The README "production-like access control" claim did not say so.
- **H4 — ANY on all interfaces**: all four host ports bound to `0.0.0.0`, and
  Docker's iptables rules bypass host firewalls, with no documented way to
  restrict the bind interface.
- **M6 — production example HostTable gaps**: the example omitted the self AE
  (`PROD_PACS`) and any sibling PACS, so a derived config would hit "no
  matching destination" for self/cross-node C-MOVE.
- **M4 — no association cap on storescp/wlmscpfs**: both are single-process
  sequential receivers with no DCMTK concurrency-cap flag; this must be
  bounded at the network boundary.

## Where

| File | Change |
|------|--------|
| `README.md` | New "What restricted mode does NOT cover" subsection; new "Restricting the published bind address" section (incl. per-service concurrency note); `PACS_BIND_ADDR` row in the env-var table |
| `docker-compose.yml` | Four `ports` mappings prefixed with `${PACS_BIND_ADDR:-0.0.0.0}:` |
| `env.default` | `PACS_BIND_ADDR=0.0.0.0` with comment |
| `config/dcmqrscp-production.cfg.example` | `self_pacs` / `sibling_pacs` HostTable rows + `all_peers` extension + C-MOVE comment |

## How

### Implementation Details
- `PACS_BIND_ADDR` defaults to `0.0.0.0`, preserving the original binding.
  The test suite and CI reach services over the Docker network, not host
  ports, so the default keeps CI green.
- Secure-by-default `127.0.0.1` is a behavior change and is intentionally
  **not** done here (tracked separately per epic #91).
- M4 documents (does not invent a flag) that storescp/wlmscpfs concurrency
  must be bounded by a network boundary, and notes dcmqrscp's existing
  `MaxAssociations`.

### Testing Done
- `docker compose config --quiet` passes with the new interpolation.
- `docker-compose.yml` and `config/**` are in the CI `paths:` filter, so the
  full `test-isolation` suite runs on this PR.

### Breaking Changes
None — the `0.0.0.0` default preserves current behavior.

## Related

Closes #87
Part of #91

Builds on #64 (container hardening) and #31 (AE whitelist profile).
