### PR TITLE
fix(tests): execute command once in run_test_expect_fail

### DIFF
--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -131,10 +131,11 @@ run_test_expect_fail() {
     shift 2
     TEST_TOTAL=$((TEST_TOTAL + 1))
 
-    local output=""
-    output=$("$@" 2>&1) || true
+    local rc=0
+    local output
+    output=$("$@" 2>&1) || rc=$?
 
-    if ! "$@" >/dev/null 2>&1; then
+    if [ "$rc" -ne 0 ]; then
         print_pass "${prefix}: ${description}"
         TEST_PASSED=$((TEST_PASSED + 1))
         return 0


### PR DESCRIPTION
## What

Rewrite `run_test_expect_fail` in `tests/test-helpers.sh` to execute the
command a single time instead of twice.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `tests/test-helpers.sh` — `run_test_expect_fail` runner

## Why

The helper ran the command twice: line 135 captured `output=$("$@" 2>&1) || true`
(the captured `output` was never used), then line 137 re-ran the same command in
`if ! "$@" >/dev/null 2>&1` to drive the verdict.

Every caller is a negative case expecting an association refusal with a `-to`
timeout (`test-echo.sh` at `-to 2`, the four rejection cases in
`test-restricted-mode.sh` at `-to 5`). Running each twice doubled the timeout
wall-clock and opened two associations per assertion; a non-deterministic command
could also diverge between the capture run and the verdict run.

- Closes #88
- Part of #91

## How

Capture the command once with explicit return-code capture:

```bash
local rc=0
local output
output=$("$@" 2>&1) || rc=$?
if [ "$rc" -ne 0 ]; then
    print_pass "..."
else
    print_fail "... (expected failure but command succeeded)"
fi
```

`rc=0` is initialized explicitly so an unset value cannot mask a failure.
Capture and verdict now share one execution. The function name, signature,
and the existing PASS/FAIL message strings are unchanged.

The deferred M5 idea (tightening `>=` to `==` on study counts) is explicitly
out of scope per issue #88 and is not touched.

### Testing Done
- `bash -n tests/test-helpers.sh` passes (syntax check).
- `tests/**` is in the CI `paths:` filter, so this PR triggers the full
  suite, including the negative-path suites (`test-echo`, `test-restricted-mode`)
  that exercise `run_test_expect_fail`.

### Breaking Changes
None.
