### PR TITLE
chore(scripts): shell-script hygiene batch

### DIFF
--- a/pacs.sh
+++ b/pacs.sh
@@ -170,7 +170,7 @@ print_status_table() {
     printf "%-20s %-12s %-14s %-10s\n" "────────────────────" "────────────" "──────────────" "──────────"
 
     for svc in "${ALL_SERVICES[@]}"; do
-        local status ae_title port cid
+        local status_label status_color ae_title port cid
 
         cid=$(service_container_id "${svc}")
 
@@ -184,14 +184,18 @@ print_status_table() {
             health=$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}-{{end}}' "${cid}" 2>/dev/null || echo "-")
         fi
 
+        # Keep the color separate from the label so the ANSI escape bytes do not
+        # count toward the printf field width; otherwise %-Nb on a colored
+        # string misaligns the STATUS column in a TTY. C_* are empty in non-TTY
+        # mode, so the uncolored output is unchanged.
         if [ "${state}" = "running" ] && [ "${health}" = "healthy" ]; then
-            status="${C_GREEN}healthy${C_RESET}"
+            status_label="healthy"; status_color="${C_GREEN}"
         elif [ "${state}" = "running" ] && [ "${health}" = "-" ]; then
-            status="${C_YELLOW}running${C_RESET}"
+            status_label="running"; status_color="${C_YELLOW}"
         elif [ "${state}" = "running" ]; then
-            status="${C_YELLOW}${health}${C_RESET}"
+            status_label="${health}"; status_color="${C_YELLOW}"
         else
-            status="${C_RED}${state}${C_RESET}"
+            status_label="${state}"; status_color="${C_RED}"
         fi
 
         # AE Title from container env
@@ -211,7 +215,12 @@ print_status_table() {
         fi
         [ -z "${port}" ] && port="-"
 
-        printf "%-20s %-22b %-14s %-10s\n" "${svc}" "${status}" "${ae_title}" "${port}"
+        # Pad the uncolored label to the column width first, then wrap the
+        # padded field in color via %b so the escape codes sit outside the
+        # measured width and the STATUS column aligns with its header.
+        local status_field
+        printf -v status_field "%-12s" "${status_label}"
+        printf "%-20s %b %-14s %-10s\n" "${svc}" "${status_color}${status_field}${C_RESET}" "${ae_title}" "${port}"
     done
     printf "\n"
 }

--- a/scripts/gen-certs.sh
+++ b/scripts/gen-certs.sh
@@ -16,9 +16,14 @@ DAYS="${TLS_CERT_DAYS:-3650}"
 mkdir -p "${CERT_DIR}"
 C="${CERT_DIR}"
 
-# Idempotent: skip if a full set already exists (e.g. on container restart or
-# when a peer already generated them into the shared volume).
-if [ -f "${C}/server-cert.pem" ] && [ -f "${C}/client-cert.pem" ] && [ -f "${C}/ca-cert.pem" ]; then
+# Idempotent: skip only if a full set (cert AND matching key for the CA,
+# server, and client) already exists, e.g. on container restart or when a peer
+# already generated them into the shared volume. Requiring the keys too means a
+# partially-wiped cert directory regenerates the missing material instead of
+# deferring the failure to dcmqrscp +tls startup.
+if [ -f "${C}/ca-cert.pem" ] && [ -f "${C}/ca-key.pem" ] \
+   && [ -f "${C}/server-cert.pem" ] && [ -f "${C}/server-key.pem" ] \
+   && [ -f "${C}/client-cert.pem" ] && [ -f "${C}/client-key.pem" ]; then
     echo "[gen-certs] certificates already present in ${C}, skipping."
     exit 0
 fi

--- a/scripts/inject-extra-peers.sh
+++ b/scripts/inject-extra-peers.sh
@@ -17,10 +17,11 @@ set -euo pipefail
 # so the destination works in both the default (ANY) and restricted (all_peers)
 # AETable modes. The all_peers match also accepts an indented line (e.g. the
 # production example). If the config has no `all_peers` line, entries are
-# inserted before `HostTable END` instead. Malformed entries (not exactly
-# name=AE:host:port, an empty field, or a non-numeric port) are skipped with a
-# warning rather than corrupting the config. awk is used (not sed) so the
-# behavior is identical on the Linux container and a macOS host.
+# inserted before `HostTable END` instead. Invalid entries are skipped with a
+# warning rather than corrupting the config: a malformed shape (not exactly
+# name=AE:host:port or an empty field), a non-numeric or out-of-range port
+# (must be 1-65535), or a symbolic name already seen in this batch. awk is used
+# (not sed) so the behavior is identical on the Linux container and a macOS host.
 
 CFG="${1:?usage: inject-extra-peers.sh <config_file>}"
 
@@ -54,6 +55,19 @@ BEGIN {
             print "inject-extra-peers: skipping peer with non-numeric port: " arr[i] > "/dev/stderr"
             continue
         }
+        # Reject ports outside the valid TCP range (1-65535). +hp[3] forces a
+        # numeric comparison; leading zeros are tolerated by the regex above.
+        if (+hp[3] < 1 || +hp[3] > 65535) {
+            print "inject-extra-peers: skipping peer with out-of-range port (1-65535): " arr[i] > "/dev/stderr"
+            continue
+        }
+        # Reject a symbolic name already seen in this batch; a duplicate
+        # HostTable definition would shadow the first and corrupt all_peers.
+        if (kv[1] in seen) {
+            print "inject-extra-peers: skipping peer with duplicate name: " arr[i] > "/dev/stderr"
+            continue
+        }
+        seen[kv[1]] = 1
         valid++
         entries[valid] = kv[1] " = (" hp[1] ", " hp[2] ", " hp[3] ")"
         names = names ", " kv[1]

--- a/scripts/wait-for-pacs.sh
+++ b/scripts/wait-for-pacs.sh
@@ -12,8 +12,15 @@ INTERVAL="${5:-2}"
 
 echo "Waiting for PACS at ${HOST}:${PORT} (AE: ${AE_TITLE})..."
 
+# Capture echoscu's stderr so a permanent misconfiguration (e.g. an AE Title
+# the SCP refuses) can be distinguished from transient non-readiness instead of
+# being swallowed for the whole retry window. The capture is reset each attempt
+# and only surfaced on the final failure.
+ECHOSCU_ERR="$(mktemp)"
+trap 'rm -f "${ECHOSCU_ERR}"' EXIT
+
 for i in $(seq 1 "${MAX_RETRIES}"); do
-    if echoscu -aec "${AE_TITLE}" "${HOST}" "${PORT}" 2>/dev/null; then
+    if echoscu -aec "${AE_TITLE}" "${HOST}" "${PORT}" 2>"${ECHOSCU_ERR}"; then
         echo "PACS ${HOST}:${PORT} is ready (attempt ${i}/${MAX_RETRIES})"
         exit 0
     fi
@@ -21,5 +28,9 @@ for i in $(seq 1 "${MAX_RETRIES}"); do
     sleep "${INTERVAL}"
 done
 
-echo "ERROR: PACS ${HOST}:${PORT} not ready after $((MAX_RETRIES * INTERVAL))s"
+echo "ERROR: PACS ${HOST}:${PORT} not ready after $((MAX_RETRIES * INTERVAL))s" >&2
+if [ -s "${ECHOSCU_ERR}" ]; then
+    echo "       last echoscu error output:" >&2
+    sed 's/^/       /' "${ECHOSCU_ERR}" >&2
+fi
 exit 1

--- a/tests/test-adhoc-peers.sh
+++ b/tests/test-adhoc-peers.sh
@@ -128,5 +128,42 @@ else
 fi
 rm -f "${CFG5}"
 
+# Test 7: out-of-range ports are skipped (0, > 65535); the valid peer lands.
+TEST_TOTAL=$((TEST_TOTAL + 1))
+CFG6=$(mktemp)
+make_cfg > "${CFG6}"
+# zero=Z:zh:0 (port < 1), big=B:bh:70000 (port > 65535), ok=OKAE:okh:11117 (valid)
+EXTRA_PEERS="zero=Z:zh:0 big=B:bh:70000 ok=OKAE:okh:11117" bash "${INJECT}" "${CFG6}" 2>/dev/null
+if grep -q 'ok = (OKAE, okh, 11117)' "${CFG6}" \
+   && grep -q 'all_peers = test_client, store_scp, ok' "${CFG6}" \
+   && ! grep -q 'zero' "${CFG6}" \
+   && ! grep -q 'big' "${CFG6}"; then
+    print_pass "inject: out-of-range ports skipped, valid peer injected"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    print_fail "inject: out-of-range port handling incorrect"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+rm -f "${CFG6}"
+
+# Test 8: a duplicate symbolic name is injected once; the duplicate is skipped.
+TEST_TOTAL=$((TEST_TOTAL + 1))
+CFG7=$(mktemp)
+make_cfg > "${CFG7}"
+# dup defined twice with different targets; only the first must be injected.
+EXTRA_PEERS="dup=AEA:ha:11118 dup=AEB:hb:11119" bash "${INJECT}" "${CFG7}" 2>/dev/null
+dup_def_count=$(grep -c '^dup = ' "${CFG7}")
+if [ "${dup_def_count}" -eq 1 ] \
+   && grep -q 'dup = (AEA, ha, 11118)' "${CFG7}" \
+   && ! grep -q 'dup = (AEB, hb, 11119)' "${CFG7}" \
+   && grep -q 'all_peers = test_client, store_scp, dup$' "${CFG7}"; then
+    print_pass "inject: duplicate name injected once, duplicate skipped"
+    TEST_PASSED=$((TEST_PASSED + 1))
+else
+    print_fail "inject: duplicate-name handling incorrect (dup_def_count=${dup_def_count})"
+    TEST_FAILED=$((TEST_FAILED + 1))
+fi
+rm -f "${CFG7}"
+
 print_summary "Ad-hoc Peers"
 [ "${TEST_FAILED}" -eq 0 ]


### PR DESCRIPTION
## What

A batch of low-severity shell-script hygiene fixes across the PACS tooling. No behavioral change to the happy path.

Change type: chore. Affected: `pacs.sh`, `scripts/gen-certs.sh`, `scripts/inject-extra-peers.sh`, `scripts/wait-for-pacs.sh`, `tests/test-adhoc-peers.sh`.

## Why

Post-0.2.0 audit remediation. Each item closes a small robustness or output-correctness gap that could otherwise surface as a confusing failure (deferred TLS startup error, corrupted HostTable, misaligned status output, or an unattributable readiness failure).

Closes #89
Part of #91

## How

- **`gen-certs.sh`** — the idempotency guard now requires the matching `*-key.pem` alongside each `*-cert.pem` (CA, server, client). A partially-wiped cert directory regenerates the missing keys instead of skipping and deferring the failure to `dcmqrscp +tls` startup.
- **`inject-extra-peers.sh`** — the awk validation now also rejects out-of-range ports (outside `1-65535`) and duplicate symbolic names, with a warning + skip, in addition to the existing numeric-port check. A duplicate `HostTable` definition would otherwise shadow the first and corrupt `all_peers`.
- **`pacs.sh`** (`print_status_table`) — the STATUS color codes are now separated from the `printf` field width: the uncolored label is padded to the column width first, then wrapped in color via `%b`, so the ANSI escape bytes no longer count toward the width and the column aligns with its header in a TTY. Non-TTY output (empty color vars) is unchanged.
- **`wait-for-pacs.sh`** — `echoscu`'s stderr is captured per attempt and surfaced on the final failure, so a permanent misconfiguration is distinguishable from transient non-readiness.

### Testing done

- `tests/test-adhoc-peers.sh`: added Test 7 (out-of-range ports `0` and `70000` skipped, valid peer injected) and Test 8 (duplicate name injected once, duplicate skipped). Full suite passes 8/8 locally.
- Verified boundary ports `1` and `65535` pass while `0` and `65536` are rejected.
- Verified the `gen-certs` guard regenerates on a partial set (cert present, key missing) and skips on a full set.
- Verified `wait-for-pacs` surfaces the captured `echoscu` stderr on the final attempt (stubbed `echoscu`).
- Verified the status table STATUS column aligns with its header after ANSI stripping.
- `bash -n` clean on all five files.

`scripts/**` and `tests/**` are in the CI `paths:` filter, so the full suite (including `Ad-hocPeers`) runs on this PR.

### Breaking changes

None.

### Rollback

Revert this PR; all changes are localized to the four scripts and one test file.
