### PR TITLE
chore(docker): pin base image digest and dcmtk apt version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 # DCMTK PACS Test Environment
 # Single image, multiple roles via ROLE environment variable
 # Based on debian:bookworm-slim with DCMTK 3.6.7 (apt)
+#
+# Base image and dcmtk apt version are pinned for reproducible, deterministic
+# builds (SBOM / CVE tracking). To refresh: pull debian:bookworm-slim, read
+# its RepoDigest and the dcmtk apt candidate (apt-cache policy dcmtk), then
+# update the digest below and the dcmtk= pin in the apt-get install step.
 
-FROM debian:bookworm-slim
+# debian:bookworm-slim pinned by digest (multi-arch manifest list).
+FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716
 
 LABEL maintainer="dcmtk-pacs-docker"
 LABEL description="DCMTK-based PACS test environment with all DICOM tools"
@@ -12,7 +18,7 @@ LABEL description="DCMTK-based PACS test environment with all DICOM tools"
 # - gettext-base: provides envsubst for config template processing
 # - netcat-openbsd: for TCP health checks (nc)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    dcmtk \
+    dcmtk=3.6.7-9~deb12u3 \
     gettext-base \
     netcat-openbsd \
     openssl \


### PR DESCRIPTION
## What

Pin the Docker build for reproducibility:

- **Base image** `debian:bookworm-slim` is now pinned by its multi-arch
  manifest digest `sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716`
  (previously tag-only).
- **dcmtk** apt package is pinned to `3.6.7-9~deb12u3` (previously unversioned;
  the `:3` comment claimed "DCMTK 3.6.7" but did not enforce it).

### Change Type
- [x] Chore (build reproducibility)

### Affected Components
- `Dockerfile` (lines 3, 5, 14-15)

## Why

`Dockerfile` pinned the base image by tag only and installed `dcmtk` with no
version constraint, so builds were non-reproducible and the dependency set was
non-deterministic for SBOM / CVE tracking. Pinning closes the audit finding in
issue #90.

This is intentionally a **separate** PR from the shell-hygiene batch (#89):
changing the base-image digest or the apt version triggers a full rebuild
across every CI job and carries registry/apt availability risk distinct from
pure shell edits, so it warrants isolated review and revert traceability.

## Where

| File | Change |
|------|--------|
| `Dockerfile:5` | `FROM` pinned by digest |
| `Dockerfile:15` | `dcmtk` pinned to exact apt version |
| `Dockerfile:3-12` | maintenance comment documenting the refresh procedure |

## How

### Resolved values (empirical)

| Pin | Resolved value | Method |
|-----|----------------|--------|
| Base digest | `sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716` | `docker pull debian:bookworm-slim` then `docker inspect --format '{{index .RepoDigests 0}}'` |
| dcmtk version | `3.6.7-9~deb12u3` | `apt-cache policy dcmtk` inside the pinned base (verified on both arm64 and the CI **amd64** platform via the pinned digest) |

The base digest is a multi-arch manifest list, so the same pin resolves
correctly on the local (arm64) host and the CI runner (`ubuntu-latest`, amd64).
`apt-cache madison dcmtk` shows `3.6.7-9~deb12u3` as the single available
version in `bookworm/main` on amd64.

### Testing Done
- [x] `docker compose build` succeeds locally with both pins (all five images
      built).
- [x] Verified the installed package version inside the built image matches the
      pin: `dpkg-query -W -f='${Version}' dcmtk` -> `3.6.7-9~deb12u3`.
- [x] `Dockerfile` is in the CI `paths:` filter, so the full `test-isolation`
      matrix rebuilds and exercises the pinned image.

### Breaking Changes
None. Same Debian point release and same dcmtk version that apt resolved before;
the pins only make the previously-implicit resolution explicit.

### Rollback Plan
Revert this PR. No runtime or data changes.

## Related Issues

- Closes #90
- Part of #91
