### PR TITLE
docs: fix fixture table, add MWL port, sync CLI tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Host Machine
 │  │ AE:TEST_SCU  │                                        │
 │  └──────────────┘                                        │
 └──────────────────────────────────────────────────────────┘
-  Host ports:  :11112  :11113  :11114
+  Host ports:  :11112  :11113  :11114  :11115
 ```
 
 ## Services
@@ -348,6 +348,7 @@ wiped safely.
 |------|------|---------|-------|
 | `data/dicom-templates/` | Source fixture | Yes | `*.dump` templates consumed by the generator; never delete |
 | `data/ct/`, `data/mr/`, `data/cr/` | Generated | No | Synthetic DICOM written on first `./pacs.sh up` |
+| `data/dicom-output/`, `data/received/` | Generated | No | Test runtime artifacts |
 
 #### Test-data manifest (single source of truth)
 
@@ -368,7 +369,6 @@ without editing a test:
 3. Point the test scripts at the target via the `PACS_HOST` / `PACS_PORT` /
    `PACS_AE_TITLE` environment variables and run them — the assertions follow
    `OID_ROOT` automatically.
-| `data/dicom-output/`, `data/received/` | Generated | No | Test runtime artifacts |
 
 To regenerate test data, remove the generated directories and restart:
 
@@ -480,6 +480,7 @@ cp env.default .env
 | `PACS2_HOST_PORT` | `11113` | Secondary PACS host port |
 | `STORESCP_AE_TITLE` | `STORE_SCP` | Store SCP receiver AE Title |
 | `STORESCP_HOST_PORT` | `11114` | Store SCP receiver host port |
+| `WLM_HOST_PORT` | `11115` | Modality Worklist SCP host port |
 | `TEST_SCU_AE_TITLE` | `TEST_SCU` | Test client AE Title |
 | `PACS_BIND_ADDR` | `0.0.0.0` | Host interface the published ports bind to. Set to e.g. `127.0.0.1` to expose ports only to the local host (see Security Notes) |
 | `DICOM_PORT` | `11112` | Internal container DICOM port |
@@ -730,7 +731,7 @@ dcmtk_docker/
 2. **Check the AE Title**: DICOM AE Titles are case-sensitive. Use exactly `DCMTK_PACS`, not `dcmtk_pacs`.
    The PACS healthcheck issues `echoscu -aec ${AE_TITLE}` against itself, so a container will be marked
    `unhealthy` if the configured `AE_TITLE` does not match what `dcmqrscp` actually loaded.
-3. **Check the port**: All containers listen on internal port `11112`. Host ports differ (11112, 11113, 11114)
+3. **Check the port**: All containers listen on internal port `11112`. Host ports differ (11112, 11113, 11114, 11115)
 4. **Check the network**: Services must be on the same Docker network (`dicom-net`)
 
 ```bash
@@ -840,7 +841,7 @@ docker compose exec test-client dcmdump +P PatientName +P StudyInstanceUID \
 
 - Docker Engine 20.10+ with Docker Compose V2
 - ~200 MB disk space for the image
-- Ports 11112-11114 available on the host (configurable via `.env`)
+- Ports 11112-11115 available on the host (configurable via `.env`)
 
 ## License
 

--- a/docs/03_architecture_design.md
+++ b/docs/03_architecture_design.md
@@ -3,6 +3,8 @@
 > Architecture document for the Docker-based DCMTK PACS test environment.
 > Based on research from `01_research_dcmtk_dicom.md` and `02_research_docker_approaches.md`.
 
+> **Baseline note:** This document is primarily the 0.1.0 design baseline; some 0.2.0 content is included. README/CHANGELOG are authoritative.
+
 ---
 
 ## Table of Contents

--- a/docs/04_work_plan.md
+++ b/docs/04_work_plan.md
@@ -3,6 +3,8 @@
 > Step-by-step implementation plan for the Docker-based DCMTK PACS test environment.
 > References `03_architecture_design.md` for all architectural decisions.
 
+> **Baseline note:** This document is primarily the 0.1.0 design baseline; some 0.2.0 content is included. README/CHANGELOG are authoritative.
+
 ---
 
 ## Table of Contents

--- a/docs/05_usage_guide.md
+++ b/docs/05_usage_guide.md
@@ -97,15 +97,18 @@ The `pacs.sh` script wraps all common operations into short subcommands:
 
 | Command | Action |
 |---------|--------|
-| `./pacs.sh up` | Auto-setup `.env`, build & start, wait for health |
+| `./pacs.sh up` | Auto-setup `.env`, build & start all services, wait for health |
 | `./pacs.sh down` | Stop all services |
 | `./pacs.sh status` | Show service health, ports, and AE titles |
-| `./pacs.sh test [suite]` | Run tests (`all`, `echo`, `store`, `find`, `move`) |
+| `./pacs.sh test [suite]` | Run tests (`all`, `echo`, `store`, `find`, `move`, `pixeldata`, `transfer-syntax`, `load-smoke`, `worklist`, `adhoc-peers`) |
+| `./pacs.sh add-peer <name> <ae> <host> <port>` | Register an ad-hoc C-MOVE destination and restart the PACS |
 | `./pacs.sh logs [service]` | Tail logs (all or specific service) |
 | `./pacs.sh shell` | Interactive bash into test-client container |
 | `./pacs.sh reset` | Wipe volumes and restart fresh |
 | `./pacs.sh clean` | Remove all containers, images, and volumes |
-| `./pacs.sh echo [host] [port]` | Quick C-ECHO connectivity check |
+| `./pacs.sh clean-data [--dry-run]` | Remove host-side generated DICOM data (preserves `data/dicom-templates` fixtures) |
+| `./pacs.sh echo [host] [port] [called-ae] [calling-ae]` | Quick C-ECHO connectivity check |
+| `./pacs.sh version` | Show the dcmtk-docker version |
 | `./pacs.sh help` | Show usage with examples |
 
 All `docker compose` commands still work directly if preferred.

--- a/pacs.sh
+++ b/pacs.sh
@@ -544,7 +544,10 @@ ${C_BOLD}Commands:${C_RESET}
   ${C_GREEN}up${C_RESET}                Build and start all services
   ${C_GREEN}down${C_RESET}              Stop all services
   ${C_GREEN}status${C_RESET}            Show service health, ports, and AE titles
-  ${C_GREEN}test${C_RESET} [suite]      Run tests (all, echo, store, find, move, pixeldata, transfer-syntax, load-smoke)
+  ${C_GREEN}test${C_RESET} [suite]      Run tests (all, echo, store, find, move, pixeldata,
+                    transfer-syntax, load-smoke, worklist, adhoc-peers)
+                    Note: the restricted-mode suite is CI-only (compose overlay),
+                    not a './pacs.sh test' target
   ${C_GREEN}logs${C_RESET} [service]    Tail logs (all or specific service)
   ${C_GREEN}shell${C_RESET}             Open bash in the test-client container
   ${C_GREEN}reset${C_RESET}             Stop, wipe volumes, and restart fresh


### PR DESCRIPTION
## What

Documentation integrity fixes across README, the design docs, and the CLI help text. This is a docs-only change (README.md, docs/**, pacs.sh).

- **README fixture table** — repaired the "Source fixtures vs generated artifacts" table: the orphaned `data/dicom-output/`, `data/received/` row was moved into the table body, and the "Test-data manifest" subsection now follows the completed table (it had been inserted into the table body, breaking GFM rendering).
- **MWL port 11115** — added the `mwl-server` host port to the architecture diagram, the troubleshooting port note, and the Requirements section, plus a new `WLM_HOST_PORT` row in the environment-variables table. The services table and capabilities (already correct) were not touched.
- **docs/05 CLI table** — synced with `README.md` (13 subcommands incl. `add-peer`/`clean-data`/`version`, 10 test suites, 4-arg `echo`).
- **pacs.sh help** — added `worklist`, `adhoc-peers` to the test-suite list and noted that `restricted` is intentionally CI-only (compose overlay), not a `pacs.sh test` target.
- **Baseline banner** — one-line banner on `docs/03_architecture_design.md` and `docs/04_work_plan.md` pointing at README/CHANGELOG as authoritative.

### Change Type
- [x] Documentation

## Why

Several documentation artifacts were internally inconsistent or stale (broken table, missing 5th-service port, stale CLI tables drifted from `pacs.sh`). Part of the post-0.2.0 audit remediation epic.

## Where

`README.md`, `docs/03_architecture_design.md`, `docs/04_work_plan.md`, `docs/05_usage_guide.md`, `pacs.sh`.

## How

Surgical edits verified against current file contents. `pacs.sh` passes `bash -n`. No functional/behavioral changes.

### CI note

This PR touches only `README.md`, `docs/**`, and `pacs.sh` — none are in the CI `paths:` filter (`tests/**`, `docker-compose.yml`, `Dockerfile`, `scripts/**`, `config/**`, workflows), so the `test-isolation` code checks are path-filtered out and will not run. GitGuardian still runs.

Closes #86
Part of #91
